### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "repository": "git@github.com:praneshr/react-diff-viewer.git",
   "license": "MIT",
   "author": "Pranesh Ravi<praneshpranesh@gmail.com>",
-  "main": "lib/index.js",
+  "main": "lib/index",
+  "typings": "lib/index",
   "scripts": {
     "build": "tsc --outDir lib/",
     "build:examples": "webpack --progress --colors",


### PR DESCRIPTION
When I try to import ReactDiffViewer, typescript throws this nasty error: "Could not find a declaration file for module...implicitly has an 'any' type." Turns out, the solution is simple, which you can find here: https://stackoverflow.com/questions/41292559/could-not-find-a-declaration-file-for-module-module-name-path-to-module-nam.

Tl;dr: I simply changed these two lines in package.json:

"main": "lib/index",
"typings": "lib/index",

^ removes the .js at the end of "lib/index.js" and adds typings

This solved the problem locally for me, but it'd be nice if this fix was automatically included for everyone! Could you please merge the changes?