### PR TITLE
hotfix/workaround for hardcoded element key

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -403,7 +403,7 @@ class DiffViewer extends React.Component<ReactDiffViewerProps, ReactDiffViewerSt
       </td>
     );
     return (
-      <tr key={Math.round(100).toString()} className={this.styles.codeFold}>
+      <tr key="skipped-line-indicator" className={this.styles.codeFold}>
         {!this.props.hideLineNumbers && (
           <td className={this.styles.codeFoldGutter} />
         )}


### PR DESCRIPTION
fixes: https://github.com/praneshr/react-diff-viewer/issues/35

This is less than ideal but it fixes the immediate problem since the rest of the keys are indexes still.  See the corresponding issue for more information on a more lasting solution.