### PR TITLE
Add support for various JsDiff text comparison methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ class Diff extends PureComponent {
 |newValue          |`string`       |`''`          |New value as string.                          |
 |splitView         |`boolean`      |`true`        |Switch between `unified` and `split` view.    |
 |disableWordDiff   |`boolean`      |`false`       |Show and hide word diff in a diff line.       |
+|jsDiffCompareMethod   |`string`      |`'diffChars'`       |JsDiff text diff method from https://github.com/kpdecker/jsdiff/tree/v4.0.1#api       |
 |hideLineNumbers   |`boolean`      |`false`       |Show and hide line numbers.                   |
 |renderContent     |`function`     |`undefined`   |Render Prop API to render code in the diff viewer. Helpful for [syntax highlighting](#syntax-highlighting)   |
 |onLineNumberClick |`function`     |`undefined`   |Event handler for line number click. `(lineId: string) => void`          |
@@ -138,6 +139,43 @@ class Diff extends PureComponent {
       <ReactDiffViewer
         oldValue={oldCode}
         newValue={newCode}
+        splitView={true}
+        renderContent={this.highlightSyntax}
+      />
+    )
+  }
+}
+```
+
+## Text block diff comparison
+
+Different styles of text block diffing are possible by using the enums corresponding to various v4.0.1 JsDiff text block method names ([learn more](https://github.com/kpdecker/jsdiff/tree/v4.0.1#api)).
+
+```javascript
+import React, { PureComponent } from 'react'
+import ReactDiffViewer, { DiffMethod } from 'react-diff-viewer'
+
+const oldCode = `
+{
+  "name": "Original name",
+  "description": null
+}
+`
+const newCode = `
+{
+  "name": "My updated name",
+  "description": "Brand new description",
+  "status": "running"
+}
+`
+
+class Diff extends PureComponent {
+  render = () => {
+    return (
+      <ReactDiffViewer
+        oldValue={oldCode}
+        newValue={newCode}
+        jsDiffCompareMethod={DiffMethod.WORDS}
         splitView={true}
         renderContent={this.highlightSyntax}
       />

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ class Diff extends PureComponent {
 |newValue          |`string`       |`''`          |New value as string.                          |
 |splitView         |`boolean`      |`true`        |Switch between `unified` and `split` view.    |
 |disableWordDiff   |`boolean`      |`false`       |Show and hide word diff in a diff line.       |
-|jsDiffCompareMethod   |`string`      |`'diffChars'`       |JsDiff text diff method from https://github.com/kpdecker/jsdiff/tree/v4.0.1#api       |
+|compareMethod   |`string`      |`'diffChars'`       |JsDiff text diff method from https://github.com/kpdecker/jsdiff/tree/v4.0.1#api       |
 |hideLineNumbers   |`boolean`      |`false`       |Show and hide line numbers.                   |
 |renderContent     |`function`     |`undefined`   |Render Prop API to render code in the diff viewer. Helpful for [syntax highlighting](#syntax-highlighting)   |
 |onLineNumberClick |`function`     |`undefined`   |Event handler for line number click. `(lineId: string) => void`          |
@@ -175,7 +175,7 @@ class Diff extends PureComponent {
       <ReactDiffViewer
         oldValue={oldCode}
         newValue={newCode}
-        jsDiffCompareMethod={DiffMethod.WORDS}
+        compareMethod={DiffMethod.WORDS}
         splitView={true}
         renderContent={this.highlightSyntax}
       />

--- a/examples/src/index.tsx
+++ b/examples/src/index.tsx
@@ -19,6 +19,7 @@ interface ExampleState {
   highlightLine?: string[];
   language?: string;
   enableSyntaxHighlighting?: boolean;
+  jsDiffCompareMethod?: string;
 }
 
 const P = (window as any).Prism;
@@ -31,6 +32,7 @@ class Example extends React.Component<{}, ExampleState> {
       highlightLine: [],
       language: 'javascript',
       enableSyntaxHighlighting: true,
+      jsDiffCompareMethod: 'diffChars'
     };
   }
 
@@ -44,6 +46,9 @@ class Example extends React.Component<{}, ExampleState> {
 
   private onLanguageChange = (e: any): void =>
     this.setState({ language: e.target.value, highlightLine: [] });
+
+  private onJsDiffCompareMethodChange = (e: any): void =>
+    this.setState({ jsDiffCompareMethod: e.target.value });
 
   private onLineNumberClick = (
     id: string,
@@ -155,16 +160,41 @@ class Example extends React.Component<{}, ExampleState> {
           </div>
         </div>
         <div className="controls">
-          <select
-            name="language"
-            id="language"
-            onChange={this.onLanguageChange}
-            value={this.state.language}
-          >
-            <option value="json">JSON</option>
-            <option value="xml">XML</option>
-            <option value="javascript">Javascript</option>
-          </select>
+          <span>
+            <label htmlFor="js_diff_compare_method">JsDiff Compare Method</label>
+            {' '}
+            (<a href="https://github.com/kpdecker/jsdiff/tree/v4.0.1#api">Learn More</a>)
+            {' '}
+            <select
+              name="js_diff_compare_method"
+              id="js_diff_compare_method"
+              onChange={this.onJsDiffCompareMethodChange}
+              value={this.state.jsDiffCompareMethod}
+            >
+              <option value="disabled">DISABLE</option>
+              <option value="diffChars">diffChars</option>
+              <option value="diffWords">diffWords</option>
+              <option value="diffWordsWithSpace">diffWordsWithSpace</option>
+              <option value="diffLines">diffLines</option>
+              <option value="diffTrimmedLines">diffTrimmedLines</option>
+              <option value="diffCss">diffCss</option>
+              <option value="diffSentences">diffSentences</option>
+            </select>
+          </span>
+          <span>
+            <label htmlFor="language">Language</label>
+            {' '}
+            <select
+              name="language"
+              id="language"
+              onChange={this.onLanguageChange}
+              value={this.state.language}
+            >
+              <option value="json">JSON</option>
+              <option value="xml">XML</option>
+              <option value="javascript">Javascript</option>
+            </select>
+          </span>
           <span>
             <label>
               <input
@@ -190,6 +220,8 @@ class Example extends React.Component<{}, ExampleState> {
         </div>
         <div className="diff-viewer">
           <ReactDiff
+            disableWordDiff={ this.state.jsDiffCompareMethod === 'disabled' }
+            jsDiffCompareMethod={ this.state.jsDiffCompareMethod }
             highlightLines={this.state.highlightLine}
             onLineNumberClick={this.onLineNumberClick}
             oldValue={oldValue}

--- a/examples/src/index.tsx
+++ b/examples/src/index.tsx
@@ -19,7 +19,7 @@ interface ExampleState {
   highlightLine?: string[];
   language?: string;
   enableSyntaxHighlighting?: boolean;
-  jsDiffCompareMethod?: string;
+  compareMethod?: string;
 }
 
 const P = (window as any).Prism;
@@ -32,7 +32,7 @@ class Example extends React.Component<{}, ExampleState> {
       highlightLine: [],
       language: 'javascript',
       enableSyntaxHighlighting: true,
-      jsDiffCompareMethod: 'diffChars'
+      compareMethod: 'diffChars'
     };
   }
 
@@ -47,8 +47,8 @@ class Example extends React.Component<{}, ExampleState> {
   private onLanguageChange = (e: any): void =>
     this.setState({ language: e.target.value, highlightLine: [] });
 
-  private onJsDiffCompareMethodChange = (e: any): void =>
-    this.setState({ jsDiffCompareMethod: e.target.value });
+  private onCompareMethodChange = (e: any): void =>
+    this.setState({ compareMethod: e.target.value });
 
   private onLineNumberClick = (
     id: string,
@@ -168,8 +168,8 @@ class Example extends React.Component<{}, ExampleState> {
             <select
               name="js_diff_compare_method"
               id="js_diff_compare_method"
-              onChange={this.onJsDiffCompareMethodChange}
-              value={this.state.jsDiffCompareMethod}
+              onChange={this.onCompareMethodChange}
+              value={this.state.compareMethod}
             >
               <option value="disabled">DISABLE</option>
               <option value="diffChars">diffChars</option>
@@ -220,8 +220,8 @@ class Example extends React.Component<{}, ExampleState> {
         </div>
         <div className="diff-viewer">
           <ReactDiff
-            disableWordDiff={ this.state.jsDiffCompareMethod === 'disabled' }
-            jsDiffCompareMethod={ this.state.jsDiffCompareMethod }
+            disableWordDiff={ this.state.compareMethod === 'disabled' }
+            compareMethod={ this.state.compareMethod }
             highlightLines={this.state.highlightLine}
             onLineNumberClick={this.onLineNumberClick}
             oldValue={oldValue}

--- a/src/compute-lines.ts
+++ b/src/compute-lines.ts
@@ -1,5 +1,7 @@
 import * as diff from 'diff';
 
+const jsDiff: { [key: string]: any } = diff;
+
 export enum DiffType {
   DEFAULT = 0,
   ADDED = 1,
@@ -17,6 +19,8 @@ export enum DiffMethod {
 }
 
 export interface DiffInformation {
+  added?: boolean;
+  removed?: boolean;
   value?: string | DiffInformation[];
   lineNumber?: number;
   type?: DiffType;
@@ -77,13 +81,13 @@ const constructLines = (value: string): string[] => {
  * @param jsDiffCompareMethod JsDiff text diff method from https://github.com/kpdecker/jsdiff/tree/v4.0.1#api
  */
 const computeDiff = (oldValue: string, newValue: string, jsDiffCompareMethod: string): ComputedDiffInformation => {
-  const diffArray = diff[jsDiffCompareMethod](oldValue, newValue);
+  const diffArray = jsDiff[jsDiffCompareMethod](oldValue, newValue);
   const computedDiff: ComputedDiffInformation = {
     left: [],
     right: [],
   };
   diffArray
-    .forEach(({ added, removed, value }): DiffInformation => {
+    .forEach(({ added, removed, value }: DiffInformation): DiffInformation => {
       const diffInformation: DiffInformation = {};
       if (added) {
         diffInformation.type = DiffType.ADDED;

--- a/src/compute-lines.ts
+++ b/src/compute-lines.ts
@@ -8,6 +8,7 @@ export enum DiffType {
   REMOVED = 2,
 }
 
+// See https://github.com/kpdecker/jsdiff/tree/v4.0.1#api for more info on the below JsDiff methods
 export enum DiffMethod {
   CHARS = 'diffChars',
   WORDS = 'diffWords',
@@ -19,8 +20,6 @@ export enum DiffMethod {
 }
 
 export interface DiffInformation {
-  added?: boolean;
-  removed?: boolean;
   value?: string | DiffInformation[];
   lineNumber?: number;
   type?: DiffType;
@@ -39,6 +38,13 @@ export interface ComputedLineInformation {
 export interface ComputedDiffInformation {
   left?: DiffInformation[];
   right?: DiffInformation[];
+}
+
+// See https://github.com/kpdecker/jsdiff/tree/v4.0.1#change-objects for more info on JsDiff Change Objects
+export interface JsDiffChangeObject {
+  added?: boolean;
+  removed?: boolean;
+  value?: string;
 }
 
 /**
@@ -78,16 +84,16 @@ const constructLines = (value: string): string[] => {
  *
  * @param oldValue Old word in the line.
  * @param newValue New word in the line.
- * @param jsDiffCompareMethod JsDiff text diff method from https://github.com/kpdecker/jsdiff/tree/v4.0.1#api
+ * @param compareMethod JsDiff text diff method from https://github.com/kpdecker/jsdiff/tree/v4.0.1#api
  */
-const computeDiff = (oldValue: string, newValue: string, jsDiffCompareMethod: string): ComputedDiffInformation => {
-  const diffArray = jsDiff[jsDiffCompareMethod](oldValue, newValue);
+const computeDiff = (oldValue: string, newValue: string, compareMethod: string): ComputedDiffInformation => {
+  const diffArray: Array<JsDiffChangeObject> = jsDiff[compareMethod](oldValue, newValue);
   const computedDiff: ComputedDiffInformation = {
     left: [],
     right: [],
   };
   diffArray
-    .forEach(({ added, removed, value }: DiffInformation): DiffInformation => {
+    .forEach(({ added, removed, value }): DiffInformation => {
       const diffInformation: DiffInformation = {};
       if (added) {
         diffInformation.type = DiffType.ADDED;
@@ -121,13 +127,13 @@ const computeDiff = (oldValue: string, newValue: string, jsDiffCompareMethod: st
  * @param oldString Old string to compare.
  * @param newString New string to compare with old string.
  * @param disableWordDiff Flag to enable/disable word diff.
- * @param jsDiffCompareMethod JsDiff text diff method from https://github.com/kpdecker/jsdiff/tree/v4.0.1#api
+ * @param compareMethod JsDiff text diff method from https://github.com/kpdecker/jsdiff/tree/v4.0.1#api
  */
 const computeLineInformation = (
   oldString: string,
   newString: string,
   disableWordDiff: boolean = false,
-  jsDiffCompareMethod: string = DiffMethod.CHARS,
+  compareMethod: string = DiffMethod.CHARS,
 ): ComputedLineInformation => {
   const diffArray = diff.diffLines(
     oldString.trimRight(),
@@ -190,10 +196,10 @@ const computeLineInformation = (
               right.type = type;
               // Do word level diff and assign the corresponding values to the
               // left and right diff information object.
-              if (disableWordDiff || !(<any>Object).values(DiffMethod).includes(jsDiffCompareMethod)) {
+              if (disableWordDiff || !(<any>Object).values(DiffMethod).includes(compareMethod)) {
                 right.value = rightValue;
               } else {
-                const computedDiff = computeDiff(line, rightValue as string, jsDiffCompareMethod);
+                const computedDiff = computeDiff(line, rightValue as string, compareMethod);
                 right.value = computedDiff.right;
                 left.value = computedDiff.left;
               }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,7 @@ import {
   LineInformation,
   DiffInformation,
   DiffType,
+  DiffMethod,
 } from './compute-lines';
 import computeStyles, { ReactDiffViewerStylesOverride, ReactDiffViewerStyles } from './styles';
 
@@ -29,6 +30,8 @@ export interface ReactDiffViewerProps {
   splitView?: boolean;
   // Enable/Disable word diff.
   disableWordDiff?: boolean;
+  // JsDiff text diff method from https://github.com/kpdecker/jsdiff/tree/v4.0.1#api
+  jsDiffCompareMethod?: string;
   // Number of unmodified lines surrounding each line diff.
   extraLinesSurroundingDiff?: number;
   // Show/hide line number.
@@ -68,6 +71,7 @@ class DiffViewer extends React.Component<ReactDiffViewerProps, ReactDiffViewerSt
     splitView: true,
     highlightLines: [],
     disableWordDiff: false,
+    jsDiffCompareMethod: DiffMethod.CHARS,
     styles: {},
     hideLineNumbers: false,
     extraLinesSurroundingDiff: 3,
@@ -79,6 +83,7 @@ class DiffViewer extends React.Component<ReactDiffViewerProps, ReactDiffViewerSt
     newValue: PropTypes.string.isRequired,
     splitView: PropTypes.bool,
     disableWordDiff: PropTypes.bool,
+    jsDiffCompareMethod: PropTypes.oneOf(Object.values(DiffMethod)),
     renderContent: PropTypes.func,
     onLineNumberClick: PropTypes.func,
     extraLinesSurroundingDiff: PropTypes.number,
@@ -420,11 +425,12 @@ class DiffViewer extends React.Component<ReactDiffViewerProps, ReactDiffViewerSt
    * Generates the entire diff view.
    */
   private renderDiff = (): JSX.Element[] => {
-    const { oldValue, newValue, splitView } = this.props;
+    const { oldValue, newValue, splitView, disableWordDiff, jsDiffCompareMethod } = this.props;
     const { lineInformation, diffLines } = computeLineInformation(
       oldValue,
       newValue,
-      this.props.disableWordDiff,
+      disableWordDiff,
+      jsDiffCompareMethod,
     );
     const extraLines = this.props.extraLinesSurroundingDiff < 0
       ? 0
@@ -501,4 +507,4 @@ class DiffViewer extends React.Component<ReactDiffViewerProps, ReactDiffViewerSt
 }
 
 export default DiffViewer;
-export { ReactDiffViewerStylesOverride };
+export { ReactDiffViewerStylesOverride, DiffMethod };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -31,7 +31,7 @@ export interface ReactDiffViewerProps {
   // Enable/Disable word diff.
   disableWordDiff?: boolean;
   // JsDiff text diff method from https://github.com/kpdecker/jsdiff/tree/v4.0.1#api
-  jsDiffCompareMethod?: string;
+  compareMethod?: string;
   // Number of unmodified lines surrounding each line diff.
   extraLinesSurroundingDiff?: number;
   // Show/hide line number.
@@ -71,7 +71,7 @@ class DiffViewer extends React.Component<ReactDiffViewerProps, ReactDiffViewerSt
     splitView: true,
     highlightLines: [],
     disableWordDiff: false,
-    jsDiffCompareMethod: DiffMethod.CHARS,
+    compareMethod: DiffMethod.CHARS,
     styles: {},
     hideLineNumbers: false,
     extraLinesSurroundingDiff: 3,
@@ -83,7 +83,7 @@ class DiffViewer extends React.Component<ReactDiffViewerProps, ReactDiffViewerSt
     newValue: PropTypes.string.isRequired,
     splitView: PropTypes.bool,
     disableWordDiff: PropTypes.bool,
-    jsDiffCompareMethod: PropTypes.oneOf(Object.values(DiffMethod)),
+    compareMethod: PropTypes.oneOf(Object.values(DiffMethod)),
     renderContent: PropTypes.func,
     onLineNumberClick: PropTypes.func,
     extraLinesSurroundingDiff: PropTypes.number,
@@ -425,12 +425,12 @@ class DiffViewer extends React.Component<ReactDiffViewerProps, ReactDiffViewerSt
    * Generates the entire diff view.
    */
   private renderDiff = (): JSX.Element[] => {
-    const { oldValue, newValue, splitView, disableWordDiff, jsDiffCompareMethod } = this.props;
+    const { oldValue, newValue, splitView, disableWordDiff, compareMethod } = this.props;
     const { lineInformation, diffLines } = computeLineInformation(
       oldValue,
       newValue,
       disableWordDiff,
-      jsDiffCompareMethod,
+      compareMethod,
     );
     const extraLines = this.props.extraLinesSurroundingDiff < 0
       ? 0

--- a/test/compute-lines-test.ts
+++ b/test/compute-lines-test.ts
@@ -199,7 +199,7 @@ describe('Testing compute lines utils', (): void => {
       });
   });
 
-  it('Should call "diffChars" jsDiff method when jsDiffCompareMethod is not provided', (): void => {
+  it('Should call "diffChars" jsDiff method when compareMethod is not provided', (): void => {
     const oldCode = `Hello World`;
     const newCode = `My Updated Name
 Also this info`;
@@ -277,7 +277,7 @@ Also this info`;
       });
   });
 
-  it('Should call "diffWords" jsDiff method when a jsDiffCompareMethod IS provided', (): void => {
+  it('Should call "diffWords" jsDiff method when a compareMethod IS provided', (): void => {
     const oldCode = `Hello World`;
     const newCode = `My Updated Name
 Also this info`;

--- a/test/compute-lines-test.ts
+++ b/test/compute-lines-test.ts
@@ -1,5 +1,5 @@
 import * as expect from 'expect';
-import { computeLineInformation } from '../src/compute-lines';
+import { computeLineInformation, DiffMethod } from '../src/compute-lines';
 
 describe('Testing compute lines utils', (): void => {
   it('Should it avoid trailing spaces', (): void => {
@@ -196,6 +196,218 @@ describe('Testing compute lines utils', (): void => {
           },
         ],
         diffLines: [1],
+      });
+  });
+
+  it('Should call "diffChars" jsDiff method when jsDiffCompareMethod is not provided', (): void => {
+    const oldCode = `Hello World`;
+    const newCode = `My Updated Name
+Also this info`;
+
+    expect(computeLineInformation(oldCode, newCode))
+      .toMatchObject({
+        lineInformation: [
+          {
+            "right": {
+              "lineNumber": 1,
+              "type": 1,
+              "value": [
+                {
+                  "type": 1,
+                  "value": "My Updat"
+                },
+                {
+                  "type": 0,
+                  "value": "e"
+                },
+                {
+                  "type": 1,
+                  "value": "d"
+                },
+                {
+                  "type": 0,
+                  "value": " "
+                },
+                {
+                  "type": 1,
+                  "value": "Name"
+                }
+              ]
+            },
+            "left": {
+              "lineNumber": 1,
+              "type": 2,
+              "value": [
+                {
+                  "type": 2,
+                  "value": "H"
+                },
+                {
+                  "type": 0,
+                  "value": "e"
+                },
+                {
+                  "type": 2,
+                  "value": "llo"
+                },
+                {
+                  "type": 0,
+                  "value": " "
+                },
+                {
+                  "type": 2,
+                  "value": "World"
+                }
+              ]
+            }
+          },
+          {
+            "right": {
+              "lineNumber": 2,
+              "type": 1,
+              "value": "Also this info"
+            },
+            "left": {}
+          }
+        ],
+        diffLines: [
+          0,
+          2,
+        ],
+      });
+  });
+
+  it('Should call "diffWords" jsDiff method when a jsDiffCompareMethod IS provided', (): void => {
+    const oldCode = `Hello World`;
+    const newCode = `My Updated Name
+Also this info`;
+
+    expect(computeLineInformation(oldCode, newCode, false, DiffMethod.WORDS))
+      .toMatchObject({
+        lineInformation: [
+          {
+            "right": {
+              "lineNumber": 1,
+              "type": 1,
+              "value": [
+                {
+                  "type": 1,
+                  "value": "My"
+                },
+                {
+                  "type": 0,
+                  "value": " "
+                },
+                {
+                  "type": 1,
+                  "value": "Updated Name"
+                }
+              ]
+            },
+            "left": {
+              "lineNumber": 1,
+              "type": 2,
+              "value": [
+                {
+                  "type": 2,
+                  "value": "Hello"
+                },
+                {
+                  "type": 0,
+                  "value": " "
+                },
+                {
+                  "type": 2,
+                  "value": "World"
+                }
+              ]
+            }
+          },
+          {
+            "right": {
+              "lineNumber": 2,
+              "type": 1,
+              "value": "Also this info"
+            },
+            "left": {}
+          }
+        ],
+        diffLines: [
+          0,
+          2
+        ],
+      });
+  });
+
+  it('Should not call jsDiff method and not diff text when unknown JsDiffMethod is passed', (): void => {
+    const oldCode = `Hello World`;
+    const newCode = `My Updated Name
+Also this info`;
+
+    expect(computeLineInformation(oldCode, newCode, false, 'unknownMethod'))
+      .toMatchObject({
+        lineInformation: [
+          {
+            "right": {
+              "lineNumber": 1,
+              "type": 1,
+              "value": "My Updated Name"
+            },
+            "left": {
+              "lineNumber": 1,
+              "type": 2,
+              "value": "Hello World"
+            }
+          },
+          {
+            "right": {
+              "lineNumber": 2,
+              "type": 1,
+              "value": "Also this info"
+            },
+            "left": {}
+          }
+        ],
+        diffLines: [
+          0,
+          2
+        ],
+      });
+  });
+
+  it('Should not call jsDiff method and not diff text when disableWordDiff is true', (): void => {
+    const oldCode = `Hello World`;
+    const newCode = `My Updated Name
+Also this info`;
+
+    expect(computeLineInformation(oldCode, newCode, true))
+      .toMatchObject({
+        lineInformation: [
+          {
+            "right": {
+              "lineNumber": 1,
+              "type": 1,
+              "value": "My Updated Name"
+            },
+            "left": {
+              "lineNumber": 1,
+              "type": 2,
+              "value": "Hello World"
+            }
+          },
+          {
+            "right": {
+              "lineNumber": 2,
+              "type": 1,
+              "value": "Also this info"
+            },
+            "left": {}
+          }
+        ],
+        diffLines: [
+          0,
+          2
+        ],
       });
   });
 });


### PR DESCRIPTION
This PR is heavily inspired by #31, but differs slightly in it's approach. This is required functionality if we're going to be able to use react-diff-viewer in our product. Today, the default text diff comparison looks like this:

<img width="1697" alt="Screen Shot 2019-11-18 at 11 58 34 PM" src="https://user-images.githubusercontent.com/7128855/69121845-e4ce0080-0a62-11ea-90b8-f81cb91c795d.png">

But it would be more desirable for the implementer to be able to specify which [JsDiff method](https://github.com/kpdecker/jsdiff/tree/v4.0.1#api) is used, creating a more desirable diff in cases like this:

<img width="1688" alt="Screen Shot 2019-11-18 at 11 58 43 PM" src="https://user-images.githubusercontent.com/7128855/69121850-e7c8f100-0a62-11ea-98cd-f44a4a5a16ef.png">

Because the proposed `jsDiffCompareMethod` prop has a default value of `diffChars`, this would be a backwards compatible and a non-breaking change. `disableWordDiff` would still exist as a different prop and we'd simply return early if an unrecognized method name was passed.

In summary, this PR will:
- Update the example app with the text diff method options
- Add readme documentation
- Add tests for the new functionality 

Some other improvements worth considering in this or subsequent PRs:
- Allowing for options documented in https://github.com/kpdecker/jsdiff/tree/v4.0.1#api

**Run this locally:**
_(NOTE: this node version works for me but someone should probably add `.nvmrc` with ideal node version)_
```
# pull this branch / PR
nvm install 12.13.0
nvm use 12.13.0
yarn
yarn build:watch 

# In separate shell
nvm use 12.13.0
yarn start:examples
```

Totally open to feedback and very interested in helping push this over the line!