### PR TITLE
fix(601): Fix unified view without line numbers expand cell bug

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -423,15 +423,16 @@ class DiffViewer extends React.Component<ReactDiffViewerProps, ReactDiffViewerSt
         </a>
       </td>
     );
+    const isUnifiedViewWithoutLineNumbers = !splitView && !hideLineNumbers;
     return (
       <tr key={`${leftBlockLineNumber}-${rightBlockLineNumber}`} className={this.styles.codeFold}>
         {!hideLineNumbers && (
           <td className={this.styles.codeFoldGutter} />
         )}
-        <td className={cn({ [this.styles.codeFoldGutter]: !splitView })} />
+        <td className={cn({ [this.styles.codeFoldGutter]: isUnifiedViewWithoutLineNumbers })} />
 
         {/* Swap columns only for unified view without line numbers */}
-        {(!splitView && !hideLineNumbers) ? (
+        {isUnifiedViewWithoutLineNumbers ? (
           <React.Fragment>
             <td />
             {content}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -411,7 +411,7 @@ class DiffViewer extends React.Component<ReactDiffViewerProps, ReactDiffViewerSt
     leftBlockLineNumber: number,
     rightBlockLineNumber: number,
   ): JSX.Element => {
-    const { splitView } = this.props;
+    const { hideLineNumbers, splitView } = this.props;
     const message = this.props.codeFoldMessageRenderer
       ? this.props
         .codeFoldMessageRenderer(num, leftBlockLineNumber, rightBlockLineNumber)
@@ -425,12 +425,24 @@ class DiffViewer extends React.Component<ReactDiffViewerProps, ReactDiffViewerSt
     );
     return (
       <tr key={`${leftBlockLineNumber}-${rightBlockLineNumber}`} className={this.styles.codeFold}>
-        {!this.props.hideLineNumbers && (
+        {!hideLineNumbers && (
           <td className={this.styles.codeFoldGutter} />
         )}
         <td className={cn({ [this.styles.codeFoldGutter]: !splitView })} />
-        {splitView ? content : <td />}
-        {!splitView ? content : <td />}
+
+        {/* Swap columns only for unified view without line numbers */}
+        {(!splitView && !hideLineNumbers) ? (
+          <React.Fragment>
+            <td />
+            {content}
+          </React.Fragment>
+        ) : (
+          <React.Fragment>
+            {content}
+            <td />
+          </React.Fragment>
+        )}
+
         <td />
         <td />
       </tr>


### PR DESCRIPTION
**Summary:**
This will fix #60, where a unified view with no line numbers needs to have the same expand button / empty cell ordering as the other views. The original ternary was a bit confusing to me so I updated it to use `<React.Fragment />` and what I think is a clearer pattern. Definitely open to feedback on that! I also needed to replicate this exception for the code-gutter class being added. See screenshots for how it all looks now on the example app.

_**p.s.** Side note / future development feature request_ - not sure how you feel about it, but I think it would be great to hook this repo up to https://github.com/storybookjs/storybook or something similar for easier feature development. The example page is beautiful but the changing of props is a little error prone and more difficult than it could be. :)

**Screenshots:**
_Unified view with no line numbers before fix_
![Screen Shot 2019-12-30 at 12 43 58 PM](https://user-images.githubusercontent.com/7128855/71595987-68b7e580-2b03-11ea-8041-9f03b7de6e83.png)

_All views after fix_
![Screen Shot 2019-12-30 at 1 01 57 PM](https://user-images.githubusercontent.com/7128855/71596298-994c4f00-2b04-11ea-9a7e-b68d5b175ae5.png)
![Screen Shot 2019-12-30 at 12 37 34 PM](https://user-images.githubusercontent.com/7128855/71595997-77060180-2b03-11ea-9264-ea20dabbeb0f.png)
![Screen Shot 2019-12-30 at 12 37 18 PM](https://user-images.githubusercontent.com/7128855/71595998-77060180-2b03-11ea-997f-9996e278aac3.png)
![Screen Shot 2019-12-30 at 12 36 37 PM](https://user-images.githubusercontent.com/7128855/71595999-77060180-2b03-11ea-9b88-864d81fc04d3.png)


