### PR TITLE
support line offset

### DIFF
--- a/src/compute-lines.ts
+++ b/src/compute-lines.ts
@@ -133,12 +133,14 @@ const computeDiff = (
  * @param newString New string to compare with old string.
  * @param disableWordDiff Flag to enable/disable word diff.
  * @param compareMethod JsDiff text diff method from https://github.com/kpdecker/jsdiff/tree/v4.0.1#api
+ * @param linesOffset line number to start counting from
  */
 const computeLineInformation = (
   oldString: string,
   newString: string,
   disableWordDiff: boolean = false,
   compareMethod: string = DiffMethod.CHARS,
+  linesOffset : number
 ): ComputedLineInformation => {
   const diffArray = diff.diffLines(
     oldString.trimRight(),
@@ -149,8 +151,8 @@ const computeLineInformation = (
       ignoreCase: false,
     },
   );
-  let rightLineNumber = 0;
-  let leftLineNumber = 0;
+  let rightLineNumber = linesOffset;
+  let leftLineNumber = linesOffset;
   let lineInformation: LineInformation[] = [];
   let counter = 0;
   const diffLines: number[] = [];

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -28,6 +28,8 @@ export interface ReactDiffViewerProps {
   newValue: string;
   // Enable/Disable split view.
   splitView?: boolean;
+  // Set line Offset
+  linesOffset?: number;
   // Enable/Disable word diff.
   disableWordDiff?: boolean;
   // JsDiff text diff method from https://github.com/kpdecker/jsdiff/tree/v4.0.1#api
@@ -83,6 +85,7 @@ class DiffViewer extends React.Component<ReactDiffViewerProps, ReactDiffViewerSt
     extraLinesSurroundingDiff: 3,
     showDiffOnly: true,
     useDarkTheme: false,
+    linesOffset: 0
   };
 
   public static propTypes = {
@@ -106,6 +109,7 @@ class DiffViewer extends React.Component<ReactDiffViewerProps, ReactDiffViewerSt
       PropTypes.string,
       PropTypes.element,
     ]),
+    linesOffset: PropTypes.number
   };
 
   public constructor(props: ReactDiffViewerProps) {
@@ -441,12 +445,13 @@ class DiffViewer extends React.Component<ReactDiffViewerProps, ReactDiffViewerSt
    * Generates the entire diff view.
    */
   private renderDiff = (): JSX.Element[] => {
-    const { oldValue, newValue, splitView, disableWordDiff, compareMethod } = this.props;
+    const { oldValue, newValue, splitView, disableWordDiff, compareMethod, linesOffset } = this.props;
     const { lineInformation, diffLines } = computeLineInformation(
       oldValue,
       newValue,
       disableWordDiff,
       compareMethod,
+      linesOffset
     );
     const extraLines = this.props.extraLinesSurroundingDiff < 0
       ? 0


### PR DESCRIPTION
i came accross an issue where i gave the component just part of the original file to compare.
diff came out as expected but line numbers started from 1 (as the component cannot realize this is not the whole file)
in order to preserve the original line numbers, i added support to linesOffset prop.
a number in which the computeLineInformation function will start to count the line numbers from.

this way i acheived the correct line numbers on a partial file comparison 
![image](https://user-images.githubusercontent.com/20145882/78161347-f6caa180-744d-11ea-9804-b4189a77490d.png)
