### PR TITLE
support line offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 <p align="center">
   <img src='https://i.ibb.co/DKrGhVQ/Frame-1-1.png' width="100%" alt='React Diff Viewer' />
 </p>
@@ -78,6 +79,7 @@ class Diff extends PureComponent {
 | useDarkTheme              | `boolean`       | `true`                         | To enable/disable dark theme.                                                                                                                                                                                                                                                                                                                                                                                    |
 | leftTitle                 | `string`        | `undefined`                    | Column title for left section of the diff in split view. This will be used as the only title in inline view.                                                                                                                                                                                                                                                                                                     |
 | rightTitle                | `string`        | `undefined`                    | Column title for right section of the diff in split view. This will be ignored in inline view.                                                                                                                                                                                                                                                                                                                   |
+| linesOffset               | `number`        | `0`                            | Number to start count code lines from.                                                                                                                                                                                                                                                                                                                                                                           |
 
 ## Instance Methods
 

--- a/src/compute-lines.ts
+++ b/src/compute-lines.ts
@@ -133,12 +133,14 @@ const computeDiff = (
  * @param newString New string to compare with old string.
  * @param disableWordDiff Flag to enable/disable word diff.
  * @param compareMethod JsDiff text diff method from https://github.com/kpdecker/jsdiff/tree/v4.0.1#api
+ * @param linesOffset line number to start counting from
  */
 const computeLineInformation = (
   oldString: string,
   newString: string,
   disableWordDiff: boolean = false,
   compareMethod: string = DiffMethod.CHARS,
+  linesOffset: number
 ): ComputedLineInformation => {
   const diffArray = diff.diffLines(
     oldString.trimRight(),
@@ -149,8 +151,8 @@ const computeLineInformation = (
       ignoreCase: false,
     },
   );
-  let rightLineNumber = 0;
-  let leftLineNumber = 0;
+  let rightLineNumber = linesOffset;
+  let leftLineNumber = linesOffset;
   let lineInformation: LineInformation[] = [];
   let counter = 0;
   const diffLines: number[] = [];

--- a/src/compute-lines.ts
+++ b/src/compute-lines.ts
@@ -140,7 +140,7 @@ const computeLineInformation = (
   newString: string,
   disableWordDiff: boolean = false,
   compareMethod: string = DiffMethod.CHARS,
-  linesOffset: number
+  linesOffset: number = 0,
 ): ComputedLineInformation => {
   const diffArray = diff.diffLines(
     oldString.trimRight(),

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -85,7 +85,7 @@ class DiffViewer extends React.Component<ReactDiffViewerProps, ReactDiffViewerSt
     extraLinesSurroundingDiff: 3,
     showDiffOnly: true,
     useDarkTheme: false,
-    linesOffset: 0
+    linesOffset: 0,
   };
 
   public static propTypes = {
@@ -109,7 +109,7 @@ class DiffViewer extends React.Component<ReactDiffViewerProps, ReactDiffViewerSt
       PropTypes.string,
       PropTypes.element,
     ]),
-    linesOffset: PropTypes.number
+    linesOffset: PropTypes.number,
   };
 
   public constructor(props: ReactDiffViewerProps) {
@@ -451,7 +451,7 @@ class DiffViewer extends React.Component<ReactDiffViewerProps, ReactDiffViewerSt
       newValue,
       disableWordDiff,
       compareMethod,
-      linesOffset
+      linesOffset,
     );
     const extraLines = this.props.extraLinesSurroundingDiff < 0
       ? 0

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -28,6 +28,8 @@ export interface ReactDiffViewerProps {
   newValue: string;
   // Enable/Disable split view.
   splitView?: boolean;
+  // Set line Offset
+  linesOffset?: number;
   // Enable/Disable word diff.
   disableWordDiff?: boolean;
   // JsDiff text diff method from https://github.com/kpdecker/jsdiff/tree/v4.0.1#api
@@ -83,6 +85,7 @@ class DiffViewer extends React.Component<ReactDiffViewerProps, ReactDiffViewerSt
     extraLinesSurroundingDiff: 3,
     showDiffOnly: true,
     useDarkTheme: false,
+    linesOffset: 0
   };
 
   public static propTypes = {
@@ -106,6 +109,7 @@ class DiffViewer extends React.Component<ReactDiffViewerProps, ReactDiffViewerSt
       PropTypes.string,
       PropTypes.element,
     ]),
+    linesOffset: PropTypes.number
   };
 
   public constructor(props: ReactDiffViewerProps) {
@@ -441,12 +445,13 @@ class DiffViewer extends React.Component<ReactDiffViewerProps, ReactDiffViewerSt
    * Generates the entire diff view.
    */
   private renderDiff = (): JSX.Element[] => {
-    const { oldValue, newValue, splitView, disableWordDiff, compareMethod } = this.props;
+    const { oldValue, newValue, splitView, disableWordDiff, compareMethod, linesOffset } = this.props;
     const { lineInformation, diffLines } = computeLineInformation(
       oldValue,
       newValue,
       disableWordDiff,
       compareMethod,
+      linesOffset
     );
     const extraLines = this.props.extraLinesSurroundingDiff < 0
       ? 0

--- a/test/compute-lines-test.ts
+++ b/test/compute-lines-test.ts
@@ -374,4 +374,40 @@ Also this info`;
         ],
       });
   });
+
+  it('Should start line counting from offset', (): void => {
+    const oldCode = 'Hello World';
+    const newCode = `My Updated Name
+Also this info`;
+
+    expect(computeLineInformation(oldCode, newCode, true, DiffMethod.WORDS, 5))
+      .toMatchObject({
+        lineInformation: [
+          {
+            right: {
+              lineNumber: 6,
+              type: 1,
+              value: 'My Updated Name',
+            },
+            left: {
+              lineNumber: 6,
+              type: 2,
+              value: 'Hello World',
+            },
+          },
+          {
+            right: {
+              lineNumber: 7,
+              type: 1,
+              value: 'Also this info',
+            },
+            left: {},
+          },
+        ],
+        diffLines: [
+          0,
+          2,
+        ],
+      });
+  });
 });


### PR DESCRIPTION
I came accross an issue where I gave the diff component just part of the original file to compare.
Diff came out as expected but line numbers started from 1 (as the component cannot realize this is not the whole file)
In order to preserve the original line numbers, I added support to linesOffset prop.
A number in which the computeLineInformation function will start to count the line numbers from.

This way I acheived the correct line numbers getting rendered n a partial file comparison.

![image](https://user-images.githubusercontent.com/20145882/78162791-1367d900-7450-11ea-8ba7-8e8b96eafb80.png)
