### PR TITLE
fix `variables.light.diffViewerColor` typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ const defaultStyles = {
   variables: {
     light: {
       diffViewerBackground: '#fff',
-      diffViewerColor: '212529',
+      diffViewerColor: '#212529',
       addedBackground: '#e6ffed',
       addedColor: '#24292e',
       removedBackground: '#ffeef0',

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -88,7 +88,7 @@ export default (
 		light: {
 			...{
 				diffViewerBackground: '#fff',
-				diffViewerColor: '212529',
+				diffViewerColor: '#212529',
 				addedBackground: '#e6ffed',
 				addedColor: '#24292e',
 				removedBackground: '#ffeef0',


### PR DESCRIPTION
Hi! Thanks for making `react-diff-viewer`! I'm using it my project and noticed that the default `diffViewerColor` has a typo:

<img width="206" alt="image" src="https://user-images.githubusercontent.com/1155589/87955083-89e72000-caad-11ea-9ea0-702d565c486b.png">
