### PR TITLE
added missing codeFold style object

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ const defaultStyles = {
   wordAdded?: {}, // style object
   wordRemoved?: {}, // style object
   codeFoldGutter?: {}, // style object
+  codeFold?: {}, // style object
   emptyLine?: {}, // style object
   content?: {}, // style object
   titleBlock?: {}, // style object


### PR DESCRIPTION
I need to set the height of the codeFold to 0 to make it not appear. I did it and it worked and i think it should be in the docs.

![image](https://user-images.githubusercontent.com/1910070/96100958-edad9900-0ea2-11eb-8283-905078c9e63e.png)
