### PR TITLE
Add missing code fold styles to types

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ const defaultStyles = {
   wordDiff?: {}, // style object
   wordAdded?: {}, // style object
   wordRemoved?: {}, // style object
+  codeFoldContent?: {}, // style object
   codeFoldGutter?: {}, // style object
   codeFold?: {}, // style object
   emptyLine?: {}, // style object

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -19,6 +19,7 @@ export interface ReactDiffViewerStyles {
 	emptyGutter?: string;
 	emptyLine?: string;
 	codeFold?: string;
+	codeFoldContent?: string;
 	titleBlock?: string;
 	content?: string;
 	splitView?: string;
@@ -71,6 +72,8 @@ export interface ReactDiffViewerStylesOverride {
 	wordDiff?: Interpolation;
 	wordAdded?: Interpolation;
 	wordRemoved?: Interpolation;
+	codeFold?: Interpolation;
+	codeFoldContent?: Interpolation;
 	codeFoldGutter?: Interpolation;
 	emptyLine?: Interpolation;
 	content?: Interpolation;

--- a/test/react-diff-viewer-test.tsx
+++ b/test/react-diff-viewer-test.tsx
@@ -51,4 +51,34 @@ describe('Testing react diff viewer', (): void => {
 
     expect(node.find('table > tbody tr').length).toEqual(9);
   });
+
+  it('It should allow overriding styles', (): void => {
+    shallow(<DiffViewer
+      oldValue={oldCode}
+      newValue={newCode}
+      styles={{
+        diffContainer: { background: "red" },
+        diffRemoved: { background: "red" },
+        diffAdded: { background: "red" },
+        splitView: { background: "red" },
+        marker: { background: "red" },
+        highlightedGutter: { background: "red" },
+        highlightedLine: { background: "red" },
+        gutter: { background: "red" },
+        line: { background: "red" },
+        wordDiff: { background: "red" },
+        wordAdded: { background: "red" },
+        wordRemoved: { background: "red" },
+        codeFoldGutter: { background: "red" },
+        codeFold: { background: "red" },
+        emptyGutter: { background: "red" },
+        emptyLine: { background: "red" },
+        lineNumber: { background: "red" },
+        contentText: { background: "red" },
+        content: { background: "red" },
+        codeFoldContent: { background: "red" },
+        titleBlock: { background: "red" },
+      }}
+    />);
+  })
 });


### PR DESCRIPTION
* Add `codeFold` and `codeFoldContent` values to `ReactDiffViewerStylesOverride`. This fixes a type error that occurs when attempting to override these styles:

  > Type '{ variables: { light: { removedBackground: string; addedBackground: string; }; }; codeFold: { background: string; borderTop: string; borderBottom: string; textAlign: string; }; codeFoldContent: { ...; }; ... 7 more ...; content: { ...; }; }' is not assignable to type 'ReactDiffViewerStylesOverride'.
  Object literal may only specify known properties, and 'codeFold' does not exist in type 'ReactDiffViewerStylesOverride'.

* Add `codeFoldContent` to `ReactDiffViewerStyles`. For completeness, since all other styles are specified here.

* Add `codeFoldContent` to README.

* Add a test for rendering the component with all available styles. This will fail if there are any type errors.