### PR TITLE
build((react)): Add support for React 17-18

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
 		"webpack-dev-server": "^3.1.9"
 	},
 	"peerDependencies": {
-		"react": "^15.3.0 || ^16.0.0",
+		"react": "^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
 		"react-dom": "^15.3.0 || ^16.0.0"
 	},
 	"engines": {


### PR DESCRIPTION
With npm version > 7 you can't use the package without `--legacy-peer-deps`