### PR TITLE
chore: adding context to custom renderContent, updated project settings 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,10 +1,14 @@
 {
   "extends": ["airbnb-base", "plugin:@typescript-eslint/recommended"],
   "rules": {
+    "quotes": "off",
     "no-tabs": "off",
-    "@typescript-eslint/indent": ["error", 2],
+    "comma-dangle": "off",
+    "operator-linebreak": "off",
+    "implicit-arrow-linebreak": "off",
+    "@typescript-eslint/indent": "off",
     "max-len": ["error", {
-      "code": 100
+      "code": 255
     }],
     "arrow-body-style": "off",
   },

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -3,5 +3,5 @@
     "tabWidth": 4,
     "useTabs": false,
     "semi": true,
-    "singleQuote": false
+    "singleQuote": true
   }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+    "trailingComma": "es5",
+    "tabWidth": 2,
+    "useTabs": false,
+    "semi": true,
+    "singleQuote": false
+  }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,6 +1,6 @@
 {
     "trailingComma": "es5",
-    "tabWidth": 2,
+    "tabWidth": 4,
     "useTabs": false,
     "semi": true,
     "singleQuote": false

--- a/README.md
+++ b/README.md
@@ -361,6 +361,8 @@ yarn start:examples
 
 Check package.json for more build scripts.
 
+To build the examples, the `node` version needs to match the `node-sass` version, i.e. for Node 14 LTS, `node-sass@^4.14` is used. Refer [this post](https://stackoverflow.com/questions/70281346/node-js-sass-version-7-0-0-is-incompatible-with-4-0-0-5-0-0-6-0-0) to learn the appropriate version.
+
 ## License
 
 MIT

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
 		"html-webpack-plugin": "^3.2.0",
 		"mini-css-extract-plugin": "^0.7.0",
 		"mocha": "^6.1.4",
-		"node-sass": "^7.0.0",
+		"node-sass": "^4.14",
+		"prettier": "^2.7.1",
 		"raw-loader": "^3.0.0",
 		"react": "^16.5.2",
 		"react-dom": "^16.5.2",
@@ -83,6 +84,6 @@
 		"react-dom": "^15.3.0 || ^16.0.0"
 	},
 	"engines": {
-		"node": ">= 8"
+		"node": ">= 14"
 	}
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,15 +3,15 @@ import * as PropTypes from "prop-types";
 import cn from "classnames";
 
 import {
-  computeLineInformation,
-  LineInformation,
-  DiffInformation,
-  DiffType,
-  DiffMethod,
+    computeLineInformation,
+    LineInformation,
+    DiffInformation,
+    DiffType,
+    DiffMethod,
 } from "./compute-lines";
 import computeStyles, {
-  ReactDiffViewerStylesOverride,
-  ReactDiffViewerStyles,
+    ReactDiffViewerStylesOverride,
+    ReactDiffViewerStyles,
 } from "./styles";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -20,600 +20,624 @@ const m = require("memoize-one");
 const memoize = m.default || m;
 
 export enum LineNumberPrefix {
-  LEFT = "L",
-  RIGHT = "R",
+    LEFT = "L",
+    RIGHT = "R",
 }
 
 export interface ReactDiffViewerProps {
-  // Old value to compare.
-  oldValue: string;
-  // New value to compare.
-  newValue: string;
-  // Enable/Disable split view.
-  splitView?: boolean;
-  // Set line Offset
-  linesOffset?: number;
-  // Enable/Disable word diff.
-  disableWordDiff?: boolean;
-  // JsDiff text diff method from https://github.com/kpdecker/jsdiff/tree/v4.0.1#api
-  compareMethod?: DiffMethod;
-  // Number of unmodified lines surrounding each line diff.
-  extraLinesSurroundingDiff?: number;
-  // Show/hide line number.
-  hideLineNumbers?: boolean;
-  // Show only diff between the two values.
-  showDiffOnly?: boolean;
-  // Render prop to format final string before displaying them in the UI. Provides the current render context information so optional rendering such as comments or code annotations can be implemented
-  renderContent?: (
-    source: string,
-    renderContext?: ReactDiffViewerRenderContext
-  ) => JSX.Element;
-  // Render prop to format code fold message.
-  codeFoldMessageRenderer?: (
-    totalFoldedLines: number,
-    leftStartLineNumber: number,
-    rightStartLineNumber: number
-  ) => JSX.Element;
-  // Event handler for line number click.
-  onLineNumberClick?: (
-    lineId: string,
-    event: React.MouseEvent<HTMLTableCellElement>
-  ) => void;
-  // Array of line ids to highlight lines.
-  highlightLines?: string[];
-  // Style overrides.
-  styles?: ReactDiffViewerStylesOverride;
-  // Use dark theme.
-  useDarkTheme?: boolean;
-  // Title for left column
-  leftTitle?: string | JSX.Element;
-  // Title for left column
-  rightTitle?: string | JSX.Element;
+    // Old value to compare.
+    oldValue: string;
+    // New value to compare.
+    newValue: string;
+    // Enable/Disable split view.
+    splitView?: boolean;
+    // Set line Offset
+    linesOffset?: number;
+    // Enable/Disable word diff.
+    disableWordDiff?: boolean;
+    // JsDiff text diff method from https://github.com/kpdecker/jsdiff/tree/v4.0.1#api
+    compareMethod?: DiffMethod;
+    // Number of unmodified lines surrounding each line diff.
+    extraLinesSurroundingDiff?: number;
+    // Show/hide line number.
+    hideLineNumbers?: boolean;
+    // Show only diff between the two values.
+    showDiffOnly?: boolean;
+    // Render prop to format final string before displaying them in the UI. Provides the current render context information so optional rendering such as comments or code annotations can be implemented
+    renderContent?: (
+        source: string,
+        renderContext?: ReactDiffViewerRenderContext
+    ) => JSX.Element;
+    // Render prop to format code fold message.
+    codeFoldMessageRenderer?: (
+        totalFoldedLines: number,
+        leftStartLineNumber: number,
+        rightStartLineNumber: number
+    ) => JSX.Element;
+    // Event handler for line number click.
+    onLineNumberClick?: (
+        lineId: string,
+        event: React.MouseEvent<HTMLTableCellElement>
+    ) => void;
+    // Array of line ids to highlight lines.
+    highlightLines?: string[];
+    // Style overrides.
+    styles?: ReactDiffViewerStylesOverride;
+    // Use dark theme.
+    useDarkTheme?: boolean;
+    // Title for left column
+    leftTitle?: string | JSX.Element;
+    // Title for left column
+    rightTitle?: string | JSX.Element;
 }
 
 export interface ReactDiffViewerState {
-  // Array holding the expanded code folding.
-  expandedBlocks?: number[];
+    // Array holding the expanded code folding.
+    expandedBlocks?: number[];
 }
 
 export interface ReactDiffViewerRenderContext {
-  lineNumber: number;
-  type: DiffType;
-  prefix: LineNumberPrefix;
-  value: string | DiffInformation[];
-  additionalLineNumber?: number;
-  additionalPrefix?: LineNumberPrefix;
+    lineNumber: number;
+    type: DiffType;
+    prefix: LineNumberPrefix;
+    value: string | DiffInformation[];
+    additionalLineNumber?: number;
+    additionalPrefix?: LineNumberPrefix;
 }
 
 class DiffViewer extends React.Component<
-  ReactDiffViewerProps,
-  ReactDiffViewerState
+    ReactDiffViewerProps,
+    ReactDiffViewerState
 > {
-  private styles: ReactDiffViewerStyles;
+    private styles: ReactDiffViewerStyles;
 
-  public static defaultProps: ReactDiffViewerProps = {
-    oldValue: "",
-    newValue: "",
-    splitView: true,
-    highlightLines: [],
-    disableWordDiff: false,
-    compareMethod: DiffMethod.CHARS,
-    styles: {},
-    hideLineNumbers: false,
-    extraLinesSurroundingDiff: 3,
-    showDiffOnly: true,
-    useDarkTheme: false,
-    linesOffset: 0,
-  };
-
-  public static propTypes = {
-    oldValue: PropTypes.string.isRequired,
-    newValue: PropTypes.string.isRequired,
-    splitView: PropTypes.bool,
-    disableWordDiff: PropTypes.bool,
-    compareMethod: PropTypes.oneOf(Object.values(DiffMethod)),
-    renderContent: PropTypes.func,
-    onLineNumberClick: PropTypes.func,
-    extraLinesSurroundingDiff: PropTypes.number,
-    styles: PropTypes.object,
-    hideLineNumbers: PropTypes.bool,
-    showDiffOnly: PropTypes.bool,
-    highlightLines: PropTypes.arrayOf(PropTypes.string),
-    leftTitle: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
-    rightTitle: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
-    linesOffset: PropTypes.number,
-  };
-
-  public constructor(props: ReactDiffViewerProps) {
-    super(props);
-
-    this.state = {
-      expandedBlocks: [],
+    public static defaultProps: ReactDiffViewerProps = {
+        oldValue: "",
+        newValue: "",
+        splitView: true,
+        highlightLines: [],
+        disableWordDiff: false,
+        compareMethod: DiffMethod.CHARS,
+        styles: {},
+        hideLineNumbers: false,
+        extraLinesSurroundingDiff: 3,
+        showDiffOnly: true,
+        useDarkTheme: false,
+        linesOffset: 0,
     };
-  }
 
-  /**
-   * Resets code block expand to the initial stage. Will be exposed to the parent component via
-   * refs.
-   */
-  public resetCodeBlocks = (): boolean => {
-    if (this.state.expandedBlocks.length > 0) {
-      this.setState({
-        expandedBlocks: [],
-      });
-      return true;
-    }
-    return false;
-  };
+    public static propTypes = {
+        oldValue: PropTypes.string.isRequired,
+        newValue: PropTypes.string.isRequired,
+        splitView: PropTypes.bool,
+        disableWordDiff: PropTypes.bool,
+        compareMethod: PropTypes.oneOf(Object.values(DiffMethod)),
+        renderContent: PropTypes.func,
+        onLineNumberClick: PropTypes.func,
+        extraLinesSurroundingDiff: PropTypes.number,
+        styles: PropTypes.object,
+        hideLineNumbers: PropTypes.bool,
+        showDiffOnly: PropTypes.bool,
+        highlightLines: PropTypes.arrayOf(PropTypes.string),
+        leftTitle: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+        rightTitle: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+        linesOffset: PropTypes.number,
+    };
 
-  /**
-   * Pushes the target expanded code block to the state. During the re-render,
-   * this value is used to expand/fold unmodified code.
-   */
-  private onBlockExpand = (id: number): void => {
-    const prevState = this.state.expandedBlocks.slice();
-    prevState.push(id);
+    public constructor(props: ReactDiffViewerProps) {
+        super(props);
 
-    this.setState({
-      expandedBlocks: prevState,
-    });
-  };
-
-  /**
-   * Computes final styles for the diff viewer. It combines the default styles with the user
-   * supplied overrides. The computed styles are cached with performance in mind.
-   *
-   * @param styles User supplied style overrides.
-   */
-  private computeStyles: (
-    styles: ReactDiffViewerStylesOverride,
-    useDarkTheme: boolean
-  ) => ReactDiffViewerStyles = memoize(computeStyles);
-
-  /**
-   * Returns a function with clicked line number in the closure. Returns an no-op function when no
-   * onLineNumberClick handler is supplied.
-   *
-   * @param id Line id of a line.
-   */
-  private onLineNumberClickProxy = (id: string): any => {
-    if (this.props.onLineNumberClick) {
-      return (e: any): void => this.props.onLineNumberClick(id, e);
-    }
-    return (): void => {};
-  };
-
-  /**
-   * Maps over the word diff and constructs the required React elements to show word diff.
-   *
-   * @param diffArray Word diff information derived from line information.
-   * @param renderer Optional renderer to format diff words. Useful for syntax highlighting.
-   */
-  private renderWordDiff = (
-    diffArray: DiffInformation[],
-    renderer?: (
-      chunk: string,
-      renderContext?: ReactDiffViewerRenderContext
-    ) => JSX.Element,
-    renderContext?: ReactDiffViewerRenderContext
-  ): JSX.Element[] => {
-    return diffArray.map((wordDiff, i): JSX.Element => {
-      return (
-        <span
-          key={i}
-          className={cn(this.styles.wordDiff, {
-            [this.styles.wordAdded]: wordDiff.type === DiffType.ADDED,
-            [this.styles.wordRemoved]: wordDiff.type === DiffType.REMOVED,
-          })}
-        >
-          {renderer
-            ? renderer(wordDiff.value as string, renderContext)
-            : wordDiff.value}
-        </span>
-      );
-    });
-  };
-
-  /**
-   * Maps over the line diff and constructs the required react elements to show line diff. It calls
-   * renderWordDiff when encountering word diff. This takes care of both inline and split view line
-   * renders.
-   *
-   * @param lineNumber Line number of the current line.
-   * @param type Type of diff of the current line.
-   * @param prefix Unique id to prefix with the line numbers.
-   * @param value Content of the line. It can be a string or a word diff array.
-   * @param additionalLineNumber Additional line number to be shown. Useful for rendering inline
-   *  diff view. Right line number will be passed as additionalLineNumber.
-   * @param additionalPrefix Similar to prefix but for additional line number.
-   */
-  private renderLine = (
-    renderContext: ReactDiffViewerRenderContext
-  ): JSX.Element => {
-    const {
-      lineNumber,
-      type,
-      prefix,
-      value,
-      additionalLineNumber,
-      additionalPrefix,
-    } = renderContext;
-    const lineNumberTemplate = `${prefix}-${lineNumber}`;
-    const additionalLineNumberTemplate = `${additionalPrefix}-${additionalLineNumber}`;
-    const highlightLine =
-      this.props.highlightLines.includes(lineNumberTemplate) ||
-      this.props.highlightLines.includes(additionalLineNumberTemplate);
-    const added = type === DiffType.ADDED;
-    const removed = type === DiffType.REMOVED;
-    let content;
-    if (Array.isArray(value)) {
-      content = this.renderWordDiff(value, this.props.renderContent);
-    } else if (this.props.renderContent) {
-      content = this.props.renderContent(value, renderContext);
-    } else {
-      content = value;
+        this.state = {
+            expandedBlocks: [],
+        };
     }
 
-    return (
-      <React.Fragment>
-        {!this.props.hideLineNumbers && (
-          <td
-            onClick={
-              lineNumber && this.onLineNumberClickProxy(lineNumberTemplate)
-            }
-            className={cn(this.styles.gutter, {
-              [this.styles.emptyGutter]: !lineNumber,
-              [this.styles.diffAdded]: added,
-              [this.styles.diffRemoved]: removed,
-              [this.styles.highlightedGutter]: highlightLine,
-            })}
-          >
-            <pre className={this.styles.lineNumber}>{lineNumber}</pre>
-          </td>
-        )}
-        {!this.props.splitView && !this.props.hideLineNumbers && (
-          <td
-            onClick={
-              additionalLineNumber &&
-              this.onLineNumberClickProxy(additionalLineNumberTemplate)
-            }
-            className={cn(this.styles.gutter, {
-              [this.styles.emptyGutter]: !additionalLineNumber,
-              [this.styles.diffAdded]: added,
-              [this.styles.diffRemoved]: removed,
-              [this.styles.highlightedGutter]: highlightLine,
-            })}
-          >
-            <pre className={this.styles.lineNumber}>{additionalLineNumber}</pre>
-          </td>
-        )}
-        <td
-          className={cn(this.styles.marker, {
-            [this.styles.emptyLine]: !content,
-            [this.styles.diffAdded]: added,
-            [this.styles.diffRemoved]: removed,
-            [this.styles.highlightedLine]: highlightLine,
-          })}
-        >
-          <pre>
-            {added && "+"}
-            {removed && "-"}
-          </pre>
-        </td>
-        <td
-          className={cn(this.styles.content, {
-            [this.styles.emptyLine]: !content,
-            [this.styles.diffAdded]: added,
-            [this.styles.diffRemoved]: removed,
-            [this.styles.highlightedLine]: highlightLine,
-          })}
-        >
-          <pre className={this.styles.contentText}>{content}</pre>
-        </td>
-      </React.Fragment>
-    );
-  };
+    /**
+     * Resets code block expand to the initial stage. Will be exposed to the parent component via
+     * refs.
+     */
+    public resetCodeBlocks = (): boolean => {
+        if (this.state.expandedBlocks.length > 0) {
+            this.setState({
+                expandedBlocks: [],
+            });
+            return true;
+        }
+        return false;
+    };
 
-  /**
-   * Generates lines for split view.
-   *
-   * @param obj Line diff information.
-   * @param obj.left Life diff information for the left pane of the split view.
-   * @param obj.right Life diff information for the right pane of the split view.
-   * @param index React key for the lines.
-   */
-  private renderSplitView = (
-    { left, right }: LineInformation,
-    index: number
-  ): JSX.Element => {
-    return (
-      <tr key={index} className={this.styles.line}>
-        {this.renderLine({
-          lineNumber: left.lineNumber,
-          type: left.type,
-          prefix: LineNumberPrefix.LEFT,
-          value: left.value,
-        })}
-        {this.renderLine({
-          lineNumber: right.lineNumber,
-          type: right.type,
-          prefix: LineNumberPrefix.RIGHT,
-          value: right.value,
-        })}
-      </tr>
-    );
-  };
+    /**
+     * Pushes the target expanded code block to the state. During the re-render,
+     * this value is used to expand/fold unmodified code.
+     */
+    private onBlockExpand = (id: number): void => {
+        const prevState = this.state.expandedBlocks.slice();
+        prevState.push(id);
 
-  /**
-   * Generates lines for inline view.
-   *
-   * @param obj Line diff information.
-   * @param obj.left Life diff information for the added section of the inline view.
-   * @param obj.right Life diff information for the removed section of the inline view.
-   * @param index React key for the lines.
-   */
-  public renderInlineView = (
-    { left, right }: LineInformation,
-    index: number
-  ): JSX.Element => {
-    let content;
-    if (left.type === DiffType.REMOVED && right.type === DiffType.ADDED) {
-      return (
-        <React.Fragment key={index}>
-          <tr className={this.styles.line}>
-            {this.renderLine({
-              lineNumber: left.lineNumber,
-              type: left.type,
-              prefix: LineNumberPrefix.LEFT,
-              value: left.value,
-            })}
-          </tr>
-          <tr className={this.styles.line}>
-            {this.renderLine({
-              lineNumber: null,
-              type: right.type,
-              prefix: LineNumberPrefix.RIGHT,
-              value: right.value,
-              additionalLineNumber: right.lineNumber,
-            })}
-          </tr>
-        </React.Fragment>
-      );
-    }
-    if (left.type === DiffType.REMOVED) {
-      content = this.renderLine({
-        lineNumber: left.lineNumber,
-        type: left.type,
-        prefix: LineNumberPrefix.LEFT,
-        value: left.value,
-      });
-    }
-    if (left.type === DiffType.DEFAULT) {
-      content = this.renderLine({
-        lineNumber: left.lineNumber,
-        type: left.type,
-        prefix: LineNumberPrefix.LEFT,
-        value: left.value,
-        additionalLineNumber: right.lineNumber,
-        additionalPrefix: LineNumberPrefix.RIGHT,
-      });
-    }
-    if (right.type === DiffType.ADDED) {
-      content = this.renderLine({
-        lineNumber: null,
-        type: right.type,
-        prefix: LineNumberPrefix.RIGHT,
-        value: right.value,
-        additionalLineNumber: right.lineNumber,
-      });
-    }
+        this.setState({
+            expandedBlocks: prevState,
+        });
+    };
 
-    return (
-      <tr key={index} className={this.styles.line}>
-        {content}
-      </tr>
-    );
-  };
+    /**
+     * Computes final styles for the diff viewer. It combines the default styles with the user
+     * supplied overrides. The computed styles are cached with performance in mind.
+     *
+     * @param styles User supplied style overrides.
+     */
+    private computeStyles: (
+        styles: ReactDiffViewerStylesOverride,
+        useDarkTheme: boolean
+    ) => ReactDiffViewerStyles = memoize(computeStyles);
 
-  /**
-   * Returns a function with clicked block number in the closure.
-   *
-   * @param id Cold fold block id.
-   */
-  private onBlockClickProxy =
-    (id: number): any =>
-    (): void =>
-      this.onBlockExpand(id);
+    /**
+     * Returns a function with clicked line number in the closure. Returns an no-op function when no
+     * onLineNumberClick handler is supplied.
+     *
+     * @param id Line id of a line.
+     */
+    private onLineNumberClickProxy = (id: string): any => {
+        if (this.props.onLineNumberClick) {
+            return (e: any): void => this.props.onLineNumberClick(id, e);
+        }
+        return (): void => {};
+    };
 
-  /**
-   * Generates cold fold block. It also uses the custom message renderer when available to show
-   * cold fold messages.
-   *
-   * @param num Number of skipped lines between two blocks.
-   * @param blockNumber Code fold block id.
-   * @param leftBlockLineNumber First left line number after the current code fold block.
-   * @param rightBlockLineNumber First right line number after the current code fold block.
-   */
-  private renderSkippedLineIndicator = (
-    num: number,
-    blockNumber: number,
-    leftBlockLineNumber: number,
-    rightBlockLineNumber: number
-  ): JSX.Element => {
-    const { hideLineNumbers, splitView } = this.props;
-    const message = this.props.codeFoldMessageRenderer ? (
-      this.props.codeFoldMessageRenderer(
-        num,
-        leftBlockLineNumber,
-        rightBlockLineNumber
-      )
-    ) : (
-      <pre className={this.styles.codeFoldContent}>Expand {num} lines ...</pre>
-    );
-    const content = (
-      <td>
-        <a onClick={this.onBlockClickProxy(blockNumber)} tabIndex={0}>
-          {message}
-        </a>
-      </td>
-    );
-    const isUnifiedViewWithoutLineNumbers = !splitView && !hideLineNumbers;
-    return (
-      <tr
-        key={`${leftBlockLineNumber}-${rightBlockLineNumber}`}
-        className={this.styles.codeFold}
-      >
-        {!hideLineNumbers && <td className={this.styles.codeFoldGutter} />}
-        <td
-          className={cn({
-            [this.styles.codeFoldGutter]: isUnifiedViewWithoutLineNumbers,
-          })}
-        />
+    /**
+     * Maps over the word diff and constructs the required React elements to show word diff.
+     *
+     * @param diffArray Word diff information derived from line information.
+     * @param renderer Optional renderer to format diff words. Useful for syntax highlighting.
+     */
+    private renderWordDiff = (
+        diffArray: DiffInformation[],
+        renderer?: (
+            chunk: string,
+            renderContext?: ReactDiffViewerRenderContext
+        ) => JSX.Element,
+        renderContext?: ReactDiffViewerRenderContext
+    ): JSX.Element[] => {
+        return diffArray.map((wordDiff, i): JSX.Element => {
+            return (
+                <span
+                    key={i}
+                    className={cn(this.styles.wordDiff, {
+                        [this.styles.wordAdded]:
+                            wordDiff.type === DiffType.ADDED,
+                        [this.styles.wordRemoved]:
+                            wordDiff.type === DiffType.REMOVED,
+                    })}
+                >
+                    {renderer
+                        ? renderer(wordDiff.value as string, renderContext)
+                        : wordDiff.value}
+                </span>
+            );
+        });
+    };
 
-        {/* Swap columns only for unified view without line numbers */}
-        {isUnifiedViewWithoutLineNumbers ? (
-          <React.Fragment>
-            <td />
-            {content}
-          </React.Fragment>
-        ) : (
-          <React.Fragment>
-            {content}
-            <td />
-          </React.Fragment>
-        )}
-
-        <td />
-        <td />
-      </tr>
-    );
-  };
-
-  /**
-   * Generates the entire diff view.
-   */
-  private renderDiff = (): JSX.Element[] => {
-    const {
-      oldValue,
-      newValue,
-      splitView,
-      disableWordDiff,
-      compareMethod,
-      linesOffset,
-    } = this.props;
-    const { lineInformation, diffLines } = computeLineInformation(
-      oldValue,
-      newValue,
-      disableWordDiff,
-      compareMethod,
-      linesOffset
-    );
-    const extraLines =
-      this.props.extraLinesSurroundingDiff < 0
-        ? 0
-        : this.props.extraLinesSurroundingDiff;
-    let skippedLines: number[] = [];
-    return lineInformation.map(
-      (line: LineInformation, i: number): JSX.Element => {
-        const diffBlockStart = diffLines[0];
-        const currentPosition = diffBlockStart - i;
-        if (this.props.showDiffOnly) {
-          if (currentPosition === -extraLines) {
-            skippedLines = [];
-            diffLines.shift();
-          }
-          if (
-            line.left.type === DiffType.DEFAULT &&
-            (currentPosition > extraLines ||
-              typeof diffBlockStart === "undefined") &&
-            !this.state.expandedBlocks.includes(diffBlockStart)
-          ) {
-            skippedLines.push(i + 1);
-            if (i === lineInformation.length - 1 && skippedLines.length > 1) {
-              return this.renderSkippedLineIndicator(
-                skippedLines.length,
-                diffBlockStart,
-                line.left.lineNumber,
-                line.right.lineNumber
-              );
-            }
-            return null;
-          }
+    /**
+     * Maps over the line diff and constructs the required react elements to show line diff. It calls
+     * renderWordDiff when encountering word diff. This takes care of both inline and split view line
+     * renders.
+     *
+     * @param lineNumber Line number of the current line.
+     * @param type Type of diff of the current line.
+     * @param prefix Unique id to prefix with the line numbers.
+     * @param value Content of the line. It can be a string or a word diff array.
+     * @param additionalLineNumber Additional line number to be shown. Useful for rendering inline
+     *  diff view. Right line number will be passed as additionalLineNumber.
+     * @param additionalPrefix Similar to prefix but for additional line number.
+     */
+    private renderLine = (
+        renderContext: ReactDiffViewerRenderContext
+    ): JSX.Element => {
+        const {
+            lineNumber,
+            type,
+            prefix,
+            value,
+            additionalLineNumber,
+            additionalPrefix,
+        } = renderContext;
+        const lineNumberTemplate = `${prefix}-${lineNumber}`;
+        const additionalLineNumberTemplate = `${additionalPrefix}-${additionalLineNumber}`;
+        const highlightLine =
+            this.props.highlightLines.includes(lineNumberTemplate) ||
+            this.props.highlightLines.includes(additionalLineNumberTemplate);
+        const added = type === DiffType.ADDED;
+        const removed = type === DiffType.REMOVED;
+        let content;
+        if (Array.isArray(value)) {
+            content = this.renderWordDiff(value, this.props.renderContent);
+        } else if (this.props.renderContent) {
+            content = this.props.renderContent(value, renderContext);
+        } else {
+            content = value;
         }
 
-        const diffNodes = splitView
-          ? this.renderSplitView(line, i)
-          : this.renderInlineView(line, i);
-
-        if (currentPosition === extraLines && skippedLines.length > 0) {
-          const { length } = skippedLines;
-          skippedLines = [];
-          return (
-            <React.Fragment key={i}>
-              {this.renderSkippedLineIndicator(
-                length,
-                diffBlockStart,
-                line.left.lineNumber,
-                line.right.lineNumber
-              )}
-              {diffNodes}
+        return (
+            <React.Fragment>
+                {!this.props.hideLineNumbers && (
+                    <td
+                        onClick={
+                            lineNumber &&
+                            this.onLineNumberClickProxy(lineNumberTemplate)
+                        }
+                        className={cn(this.styles.gutter, {
+                            [this.styles.emptyGutter]: !lineNumber,
+                            [this.styles.diffAdded]: added,
+                            [this.styles.diffRemoved]: removed,
+                            [this.styles.highlightedGutter]: highlightLine,
+                        })}
+                    >
+                        <pre className={this.styles.lineNumber}>
+                            {lineNumber}
+                        </pre>
+                    </td>
+                )}
+                {!this.props.splitView && !this.props.hideLineNumbers && (
+                    <td
+                        onClick={
+                            additionalLineNumber &&
+                            this.onLineNumberClickProxy(
+                                additionalLineNumberTemplate
+                            )
+                        }
+                        className={cn(this.styles.gutter, {
+                            [this.styles.emptyGutter]: !additionalLineNumber,
+                            [this.styles.diffAdded]: added,
+                            [this.styles.diffRemoved]: removed,
+                            [this.styles.highlightedGutter]: highlightLine,
+                        })}
+                    >
+                        <pre className={this.styles.lineNumber}>
+                            {additionalLineNumber}
+                        </pre>
+                    </td>
+                )}
+                <td
+                    className={cn(this.styles.marker, {
+                        [this.styles.emptyLine]: !content,
+                        [this.styles.diffAdded]: added,
+                        [this.styles.diffRemoved]: removed,
+                        [this.styles.highlightedLine]: highlightLine,
+                    })}
+                >
+                    <pre>
+                        {added && "+"}
+                        {removed && "-"}
+                    </pre>
+                </td>
+                <td
+                    className={cn(this.styles.content, {
+                        [this.styles.emptyLine]: !content,
+                        [this.styles.diffAdded]: added,
+                        [this.styles.diffRemoved]: removed,
+                        [this.styles.highlightedLine]: highlightLine,
+                    })}
+                >
+                    <pre className={this.styles.contentText}>{content}</pre>
+                </td>
             </React.Fragment>
-          );
+        );
+    };
+
+    /**
+     * Generates lines for split view.
+     *
+     * @param obj Line diff information.
+     * @param obj.left Life diff information for the left pane of the split view.
+     * @param obj.right Life diff information for the right pane of the split view.
+     * @param index React key for the lines.
+     */
+    private renderSplitView = (
+        { left, right }: LineInformation,
+        index: number
+    ): JSX.Element => {
+        return (
+            <tr key={index} className={this.styles.line}>
+                {this.renderLine({
+                    lineNumber: left.lineNumber,
+                    type: left.type,
+                    prefix: LineNumberPrefix.LEFT,
+                    value: left.value,
+                })}
+                {this.renderLine({
+                    lineNumber: right.lineNumber,
+                    type: right.type,
+                    prefix: LineNumberPrefix.RIGHT,
+                    value: right.value,
+                })}
+            </tr>
+        );
+    };
+
+    /**
+     * Generates lines for inline view.
+     *
+     * @param obj Line diff information.
+     * @param obj.left Life diff information for the added section of the inline view.
+     * @param obj.right Life diff information for the removed section of the inline view.
+     * @param index React key for the lines.
+     */
+    public renderInlineView = (
+        { left, right }: LineInformation,
+        index: number
+    ): JSX.Element => {
+        let content;
+        if (left.type === DiffType.REMOVED && right.type === DiffType.ADDED) {
+            return (
+                <React.Fragment key={index}>
+                    <tr className={this.styles.line}>
+                        {this.renderLine({
+                            lineNumber: left.lineNumber,
+                            type: left.type,
+                            prefix: LineNumberPrefix.LEFT,
+                            value: left.value,
+                        })}
+                    </tr>
+                    <tr className={this.styles.line}>
+                        {this.renderLine({
+                            lineNumber: null,
+                            type: right.type,
+                            prefix: LineNumberPrefix.RIGHT,
+                            value: right.value,
+                            additionalLineNumber: right.lineNumber,
+                        })}
+                    </tr>
+                </React.Fragment>
+            );
         }
-        return diffNodes;
-      }
-    );
-  };
+        if (left.type === DiffType.REMOVED) {
+            content = this.renderLine({
+                lineNumber: left.lineNumber,
+                type: left.type,
+                prefix: LineNumberPrefix.LEFT,
+                value: left.value,
+            });
+        }
+        if (left.type === DiffType.DEFAULT) {
+            content = this.renderLine({
+                lineNumber: left.lineNumber,
+                type: left.type,
+                prefix: LineNumberPrefix.LEFT,
+                value: left.value,
+                additionalLineNumber: right.lineNumber,
+                additionalPrefix: LineNumberPrefix.RIGHT,
+            });
+        }
+        if (right.type === DiffType.ADDED) {
+            content = this.renderLine({
+                lineNumber: null,
+                type: right.type,
+                prefix: LineNumberPrefix.RIGHT,
+                value: right.value,
+                additionalLineNumber: right.lineNumber,
+            });
+        }
 
-  public render = (): JSX.Element => {
-    const {
-      oldValue,
-      newValue,
-      useDarkTheme,
-      leftTitle,
-      rightTitle,
-      splitView,
-      hideLineNumbers,
-    } = this.props;
+        return (
+            <tr key={index} className={this.styles.line}>
+                {content}
+            </tr>
+        );
+    };
 
-    if (typeof oldValue !== "string" || typeof newValue !== "string") {
-      throw Error('"oldValue" and "newValue" should be strings');
-    }
+    /**
+     * Returns a function with clicked block number in the closure.
+     *
+     * @param id Cold fold block id.
+     */
+    private onBlockClickProxy =
+        (id: number): any =>
+        (): void =>
+            this.onBlockExpand(id);
 
-    this.styles = this.computeStyles(this.props.styles, useDarkTheme);
-    const nodes = this.renderDiff();
-    const colSpanOnSplitView = hideLineNumbers ? 2 : 3;
-    const colSpanOnInlineView = hideLineNumbers ? 2 : 4;
+    /**
+     * Generates cold fold block. It also uses the custom message renderer when available to show
+     * cold fold messages.
+     *
+     * @param num Number of skipped lines between two blocks.
+     * @param blockNumber Code fold block id.
+     * @param leftBlockLineNumber First left line number after the current code fold block.
+     * @param rightBlockLineNumber First right line number after the current code fold block.
+     */
+    private renderSkippedLineIndicator = (
+        num: number,
+        blockNumber: number,
+        leftBlockLineNumber: number,
+        rightBlockLineNumber: number
+    ): JSX.Element => {
+        const { hideLineNumbers, splitView } = this.props;
+        const message = this.props.codeFoldMessageRenderer ? (
+            this.props.codeFoldMessageRenderer(
+                num,
+                leftBlockLineNumber,
+                rightBlockLineNumber
+            )
+        ) : (
+            <pre className={this.styles.codeFoldContent}>
+                Expand {num} lines ...
+            </pre>
+        );
+        const content = (
+            <td>
+                <a onClick={this.onBlockClickProxy(blockNumber)} tabIndex={0}>
+                    {message}
+                </a>
+            </td>
+        );
+        const isUnifiedViewWithoutLineNumbers = !splitView && !hideLineNumbers;
+        return (
+            <tr
+                key={`${leftBlockLineNumber}-${rightBlockLineNumber}`}
+                className={this.styles.codeFold}
+            >
+                {!hideLineNumbers && (
+                    <td className={this.styles.codeFoldGutter} />
+                )}
+                <td
+                    className={cn({
+                        [this.styles.codeFoldGutter]:
+                            isUnifiedViewWithoutLineNumbers,
+                    })}
+                />
 
-    const title = (leftTitle || rightTitle) && (
-      <tr>
-        <td
-          colSpan={splitView ? colSpanOnSplitView : colSpanOnInlineView}
-          className={this.styles.titleBlock}
-        >
-          <pre className={this.styles.contentText}>{leftTitle}</pre>
-        </td>
-        {splitView && (
-          <td colSpan={colSpanOnSplitView} className={this.styles.titleBlock}>
-            <pre className={this.styles.contentText}>{rightTitle}</pre>
-          </td>
-        )}
-      </tr>
-    );
+                {/* Swap columns only for unified view without line numbers */}
+                {isUnifiedViewWithoutLineNumbers ? (
+                    <React.Fragment>
+                        <td />
+                        {content}
+                    </React.Fragment>
+                ) : (
+                    <React.Fragment>
+                        {content}
+                        <td />
+                    </React.Fragment>
+                )}
 
-    return (
-      <table
-        className={cn(this.styles.diffContainer, {
-          [this.styles.splitView]: splitView,
-        })}
-      >
-        <tbody>
-          {title}
-          {nodes}
-        </tbody>
-      </table>
-    );
-  };
+                <td />
+                <td />
+            </tr>
+        );
+    };
+
+    /**
+     * Generates the entire diff view.
+     */
+    private renderDiff = (): JSX.Element[] => {
+        const {
+            oldValue,
+            newValue,
+            splitView,
+            disableWordDiff,
+            compareMethod,
+            linesOffset,
+        } = this.props;
+        const { lineInformation, diffLines } = computeLineInformation(
+            oldValue,
+            newValue,
+            disableWordDiff,
+            compareMethod,
+            linesOffset
+        );
+        const extraLines =
+            this.props.extraLinesSurroundingDiff < 0
+                ? 0
+                : this.props.extraLinesSurroundingDiff;
+        let skippedLines: number[] = [];
+        return lineInformation.map(
+            (line: LineInformation, i: number): JSX.Element => {
+                const diffBlockStart = diffLines[0];
+                const currentPosition = diffBlockStart - i;
+                if (this.props.showDiffOnly) {
+                    if (currentPosition === -extraLines) {
+                        skippedLines = [];
+                        diffLines.shift();
+                    }
+                    if (
+                        line.left.type === DiffType.DEFAULT &&
+                        (currentPosition > extraLines ||
+                            typeof diffBlockStart === "undefined") &&
+                        !this.state.expandedBlocks.includes(diffBlockStart)
+                    ) {
+                        skippedLines.push(i + 1);
+                        if (
+                            i === lineInformation.length - 1 &&
+                            skippedLines.length > 1
+                        ) {
+                            return this.renderSkippedLineIndicator(
+                                skippedLines.length,
+                                diffBlockStart,
+                                line.left.lineNumber,
+                                line.right.lineNumber
+                            );
+                        }
+                        return null;
+                    }
+                }
+
+                const diffNodes = splitView
+                    ? this.renderSplitView(line, i)
+                    : this.renderInlineView(line, i);
+
+                if (currentPosition === extraLines && skippedLines.length > 0) {
+                    const { length } = skippedLines;
+                    skippedLines = [];
+                    return (
+                        <React.Fragment key={i}>
+                            {this.renderSkippedLineIndicator(
+                                length,
+                                diffBlockStart,
+                                line.left.lineNumber,
+                                line.right.lineNumber
+                            )}
+                            {diffNodes}
+                        </React.Fragment>
+                    );
+                }
+                return diffNodes;
+            }
+        );
+    };
+
+    public render = (): JSX.Element => {
+        const {
+            oldValue,
+            newValue,
+            useDarkTheme,
+            leftTitle,
+            rightTitle,
+            splitView,
+            hideLineNumbers,
+        } = this.props;
+
+        if (typeof oldValue !== "string" || typeof newValue !== "string") {
+            throw Error('"oldValue" and "newValue" should be strings');
+        }
+
+        this.styles = this.computeStyles(this.props.styles, useDarkTheme);
+        const nodes = this.renderDiff();
+        const colSpanOnSplitView = hideLineNumbers ? 2 : 3;
+        const colSpanOnInlineView = hideLineNumbers ? 2 : 4;
+
+        const title = (leftTitle || rightTitle) && (
+            <tr>
+                <td
+                    colSpan={
+                        splitView ? colSpanOnSplitView : colSpanOnInlineView
+                    }
+                    className={this.styles.titleBlock}
+                >
+                    <pre className={this.styles.contentText}>{leftTitle}</pre>
+                </td>
+                {splitView && (
+                    <td
+                        colSpan={colSpanOnSplitView}
+                        className={this.styles.titleBlock}
+                    >
+                        <pre className={this.styles.contentText}>
+                            {rightTitle}
+                        </pre>
+                    </td>
+                )}
+            </tr>
+        );
+
+        return (
+            <table
+                className={cn(this.styles.diffContainer, {
+                    [this.styles.splitView]: splitView,
+                })}
+            >
+                <tbody>
+                    {title}
+                    {nodes}
+                </tbody>
+            </table>
+        );
+    };
 }
 
 export default DiffViewer;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
-import * as PropTypes from "prop-types";
-import cn from "classnames";
+import * as React from 'react';
+import * as PropTypes from 'prop-types';
+import cn from 'classnames';
 
 import {
     computeLineInformation,
@@ -8,20 +8,20 @@ import {
     DiffInformation,
     DiffType,
     DiffMethod,
-} from "./compute-lines";
+} from './compute-lines';
 import computeStyles, {
     ReactDiffViewerStylesOverride,
     ReactDiffViewerStyles,
-} from "./styles";
+} from './styles';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const m = require("memoize-one");
+const m = require('memoize-one');
 
 const memoize = m.default || m;
 
 export enum LineNumberPrefix {
-    LEFT = "L",
-    RIGHT = "R",
+    LEFT = 'L',
+    RIGHT = 'R',
 }
 
 export interface ReactDiffViewerProps {
@@ -92,8 +92,8 @@ class DiffViewer extends React.Component<
     private styles: ReactDiffViewerStyles;
 
     public static defaultProps: ReactDiffViewerProps = {
-        oldValue: "",
-        newValue: "",
+        oldValue: '',
+        newValue: '',
         splitView: true,
         highlightLines: [],
         disableWordDiff: false,
@@ -305,8 +305,8 @@ class DiffViewer extends React.Component<
                     })}
                 >
                     <pre>
-                        {added && "+"}
-                        {removed && "-"}
+                        {added && '+'}
+                        {removed && '-'}
                     </pre>
                 </td>
                 <td
@@ -539,7 +539,7 @@ class DiffViewer extends React.Component<
                     if (
                         line.left.type === DiffType.DEFAULT &&
                         (currentPosition > extraLines ||
-                            typeof diffBlockStart === "undefined") &&
+                            typeof diffBlockStart === 'undefined') &&
                         !this.state.expandedBlocks.includes(diffBlockStart)
                     ) {
                         skippedLines.push(i + 1);
@@ -593,7 +593,7 @@ class DiffViewer extends React.Component<
             hideLineNumbers,
         } = this.props;
 
-        if (typeof oldValue !== "string" || typeof newValue !== "string") {
+        if (typeof oldValue !== 'string' || typeof newValue !== 'string') {
             throw Error('"oldValue" and "newValue" should be strings');
         }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,592 +1,619 @@
-import * as React from 'react';
-import * as PropTypes from 'prop-types';
-import cn from 'classnames';
+import * as React from "react";
+import * as PropTypes from "prop-types";
+import cn from "classnames";
 
 import {
-	computeLineInformation,
-	LineInformation,
-	DiffInformation,
-	DiffType,
-	DiffMethod,
-} from './compute-lines';
+  computeLineInformation,
+  LineInformation,
+  DiffInformation,
+  DiffType,
+  DiffMethod,
+} from "./compute-lines";
 import computeStyles, {
-	ReactDiffViewerStylesOverride,
-	ReactDiffViewerStyles,
-} from './styles';
+  ReactDiffViewerStylesOverride,
+  ReactDiffViewerStyles,
+} from "./styles";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const m = require('memoize-one');
+const m = require("memoize-one");
 
 const memoize = m.default || m;
 
 export enum LineNumberPrefix {
-	LEFT = 'L',
-	RIGHT = 'R',
+  LEFT = "L",
+  RIGHT = "R",
 }
 
 export interface ReactDiffViewerProps {
-	// Old value to compare.
-	oldValue: string;
-	// New value to compare.
-	newValue: string;
-	// Enable/Disable split view.
-	splitView?: boolean;
-	// Set line Offset
-	linesOffset?: number;
-	// Enable/Disable word diff.
-	disableWordDiff?: boolean;
-	// JsDiff text diff method from https://github.com/kpdecker/jsdiff/tree/v4.0.1#api
-	compareMethod?: DiffMethod;
-	// Number of unmodified lines surrounding each line diff.
-	extraLinesSurroundingDiff?: number;
-	// Show/hide line number.
-	hideLineNumbers?: boolean;
-	// Show only diff between the two values.
-	showDiffOnly?: boolean;
-	// Render prop to format final string before displaying them in the UI.
-	renderContent?: (source: string) => JSX.Element;
-	// Render prop to format code fold message.
-	codeFoldMessageRenderer?: (
-		totalFoldedLines: number,
-		leftStartLineNumber: number,
-		rightStartLineNumber: number,
-	) => JSX.Element;
-	// Event handler for line number click.
-	onLineNumberClick?: (
-		lineId: string,
-		event: React.MouseEvent<HTMLTableCellElement>,
-	) => void;
-	// Array of line ids to highlight lines.
-	highlightLines?: string[];
-	// Style overrides.
-	styles?: ReactDiffViewerStylesOverride;
-	// Use dark theme.
-	useDarkTheme?: boolean;
-	// Title for left column
-	leftTitle?: string | JSX.Element;
-	// Title for left column
-	rightTitle?: string | JSX.Element;
+  // Old value to compare.
+  oldValue: string;
+  // New value to compare.
+  newValue: string;
+  // Enable/Disable split view.
+  splitView?: boolean;
+  // Set line Offset
+  linesOffset?: number;
+  // Enable/Disable word diff.
+  disableWordDiff?: boolean;
+  // JsDiff text diff method from https://github.com/kpdecker/jsdiff/tree/v4.0.1#api
+  compareMethod?: DiffMethod;
+  // Number of unmodified lines surrounding each line diff.
+  extraLinesSurroundingDiff?: number;
+  // Show/hide line number.
+  hideLineNumbers?: boolean;
+  // Show only diff between the two values.
+  showDiffOnly?: boolean;
+  // Render prop to format final string before displaying them in the UI. Provides the current render context information so optional rendering such as comments or code annotations can be implemented
+  renderContent?: (
+    source: string,
+    renderContext?: ReactDiffViewerRenderContext
+  ) => JSX.Element;
+  // Render prop to format code fold message.
+  codeFoldMessageRenderer?: (
+    totalFoldedLines: number,
+    leftStartLineNumber: number,
+    rightStartLineNumber: number
+  ) => JSX.Element;
+  // Event handler for line number click.
+  onLineNumberClick?: (
+    lineId: string,
+    event: React.MouseEvent<HTMLTableCellElement>
+  ) => void;
+  // Array of line ids to highlight lines.
+  highlightLines?: string[];
+  // Style overrides.
+  styles?: ReactDiffViewerStylesOverride;
+  // Use dark theme.
+  useDarkTheme?: boolean;
+  // Title for left column
+  leftTitle?: string | JSX.Element;
+  // Title for left column
+  rightTitle?: string | JSX.Element;
 }
 
 export interface ReactDiffViewerState {
-	// Array holding the expanded code folding.
-	expandedBlocks?: number[];
+  // Array holding the expanded code folding.
+  expandedBlocks?: number[];
+}
+
+export interface ReactDiffViewerRenderContext {
+  lineNumber: number;
+  type: DiffType;
+  prefix: LineNumberPrefix;
+  value: string | DiffInformation[];
+  additionalLineNumber?: number;
+  additionalPrefix?: LineNumberPrefix;
 }
 
 class DiffViewer extends React.Component<
-	ReactDiffViewerProps,
-	ReactDiffViewerState
+  ReactDiffViewerProps,
+  ReactDiffViewerState
 > {
-	private styles: ReactDiffViewerStyles;
+  private styles: ReactDiffViewerStyles;
 
-	public static defaultProps: ReactDiffViewerProps = {
-		oldValue: '',
-		newValue: '',
-		splitView: true,
-		highlightLines: [],
-		disableWordDiff: false,
-		compareMethod: DiffMethod.CHARS,
-		styles: {},
-		hideLineNumbers: false,
-		extraLinesSurroundingDiff: 3,
-		showDiffOnly: true,
-		useDarkTheme: false,
-		linesOffset: 0,
-	};
+  public static defaultProps: ReactDiffViewerProps = {
+    oldValue: "",
+    newValue: "",
+    splitView: true,
+    highlightLines: [],
+    disableWordDiff: false,
+    compareMethod: DiffMethod.CHARS,
+    styles: {},
+    hideLineNumbers: false,
+    extraLinesSurroundingDiff: 3,
+    showDiffOnly: true,
+    useDarkTheme: false,
+    linesOffset: 0,
+  };
 
-	public static propTypes = {
-		oldValue: PropTypes.string.isRequired,
-		newValue: PropTypes.string.isRequired,
-		splitView: PropTypes.bool,
-		disableWordDiff: PropTypes.bool,
-		compareMethod: PropTypes.oneOf(Object.values(DiffMethod)),
-		renderContent: PropTypes.func,
-		onLineNumberClick: PropTypes.func,
-		extraLinesSurroundingDiff: PropTypes.number,
-		styles: PropTypes.object,
-		hideLineNumbers: PropTypes.bool,
-		showDiffOnly: PropTypes.bool,
-		highlightLines: PropTypes.arrayOf(PropTypes.string),
-		leftTitle: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
-		rightTitle: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
-		linesOffset: PropTypes.number,
-	};
+  public static propTypes = {
+    oldValue: PropTypes.string.isRequired,
+    newValue: PropTypes.string.isRequired,
+    splitView: PropTypes.bool,
+    disableWordDiff: PropTypes.bool,
+    compareMethod: PropTypes.oneOf(Object.values(DiffMethod)),
+    renderContent: PropTypes.func,
+    onLineNumberClick: PropTypes.func,
+    extraLinesSurroundingDiff: PropTypes.number,
+    styles: PropTypes.object,
+    hideLineNumbers: PropTypes.bool,
+    showDiffOnly: PropTypes.bool,
+    highlightLines: PropTypes.arrayOf(PropTypes.string),
+    leftTitle: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+    rightTitle: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+    linesOffset: PropTypes.number,
+  };
 
-	public constructor(props: ReactDiffViewerProps) {
-		super(props);
+  public constructor(props: ReactDiffViewerProps) {
+    super(props);
 
-		this.state = {
-			expandedBlocks: [],
-		};
-	}
+    this.state = {
+      expandedBlocks: [],
+    };
+  }
 
-	/**
-	 * Resets code block expand to the initial stage. Will be exposed to the parent component via
-	 * refs.
-	 */
-	public resetCodeBlocks = (): boolean => {
-		if (this.state.expandedBlocks.length > 0) {
-			this.setState({
-				expandedBlocks: [],
-			});
-			return true;
-		}
-		return false;
-	};
+  /**
+   * Resets code block expand to the initial stage. Will be exposed to the parent component via
+   * refs.
+   */
+  public resetCodeBlocks = (): boolean => {
+    if (this.state.expandedBlocks.length > 0) {
+      this.setState({
+        expandedBlocks: [],
+      });
+      return true;
+    }
+    return false;
+  };
 
-	/**
-	 * Pushes the target expanded code block to the state. During the re-render,
-	 * this value is used to expand/fold unmodified code.
-	 */
-	private onBlockExpand = (id: number): void => {
-		const prevState = this.state.expandedBlocks.slice();
-		prevState.push(id);
+  /**
+   * Pushes the target expanded code block to the state. During the re-render,
+   * this value is used to expand/fold unmodified code.
+   */
+  private onBlockExpand = (id: number): void => {
+    const prevState = this.state.expandedBlocks.slice();
+    prevState.push(id);
 
-		this.setState({
-			expandedBlocks: prevState,
-		});
-	};
+    this.setState({
+      expandedBlocks: prevState,
+    });
+  };
 
-	/**
-	 * Computes final styles for the diff viewer. It combines the default styles with the user
-	 * supplied overrides. The computed styles are cached with performance in mind.
-	 *
-	 * @param styles User supplied style overrides.
-	 */
-	private computeStyles: (
-		styles: ReactDiffViewerStylesOverride,
-		useDarkTheme: boolean,
-	) => ReactDiffViewerStyles = memoize(computeStyles);
+  /**
+   * Computes final styles for the diff viewer. It combines the default styles with the user
+   * supplied overrides. The computed styles are cached with performance in mind.
+   *
+   * @param styles User supplied style overrides.
+   */
+  private computeStyles: (
+    styles: ReactDiffViewerStylesOverride,
+    useDarkTheme: boolean
+  ) => ReactDiffViewerStyles = memoize(computeStyles);
 
-	/**
-	 * Returns a function with clicked line number in the closure. Returns an no-op function when no
-	 * onLineNumberClick handler is supplied.
-	 *
-	 * @param id Line id of a line.
-	 */
-	private onLineNumberClickProxy = (id: string): any => {
-		if (this.props.onLineNumberClick) {
-			return (e: any): void => this.props.onLineNumberClick(id, e);
-		}
-		return (): void => {};
-	};
+  /**
+   * Returns a function with clicked line number in the closure. Returns an no-op function when no
+   * onLineNumberClick handler is supplied.
+   *
+   * @param id Line id of a line.
+   */
+  private onLineNumberClickProxy = (id: string): any => {
+    if (this.props.onLineNumberClick) {
+      return (e: any): void => this.props.onLineNumberClick(id, e);
+    }
+    return (): void => {};
+  };
 
-	/**
-	 * Maps over the word diff and constructs the required React elements to show word diff.
-	 *
-	 * @param diffArray Word diff information derived from line information.
-	 * @param renderer Optional renderer to format diff words. Useful for syntax highlighting.
-	 */
-	private renderWordDiff = (
-		diffArray: DiffInformation[],
-		renderer?: (chunk: string) => JSX.Element,
-	): JSX.Element[] => {
-		return diffArray.map(
-			(wordDiff, i): JSX.Element => {
-				return (
-					<span
-						key={i}
-						className={cn(this.styles.wordDiff, {
-							[this.styles.wordAdded]: wordDiff.type === DiffType.ADDED,
-							[this.styles.wordRemoved]: wordDiff.type === DiffType.REMOVED,
-						})}>
-						{renderer ? renderer(wordDiff.value as string) : wordDiff.value}
-					</span>
-				);
-			},
-		);
-	};
+  /**
+   * Maps over the word diff and constructs the required React elements to show word diff.
+   *
+   * @param diffArray Word diff information derived from line information.
+   * @param renderer Optional renderer to format diff words. Useful for syntax highlighting.
+   */
+  private renderWordDiff = (
+    diffArray: DiffInformation[],
+    renderer?: (
+      chunk: string,
+      renderContext?: ReactDiffViewerRenderContext
+    ) => JSX.Element,
+    renderContext?: ReactDiffViewerRenderContext
+  ): JSX.Element[] => {
+    return diffArray.map((wordDiff, i): JSX.Element => {
+      return (
+        <span
+          key={i}
+          className={cn(this.styles.wordDiff, {
+            [this.styles.wordAdded]: wordDiff.type === DiffType.ADDED,
+            [this.styles.wordRemoved]: wordDiff.type === DiffType.REMOVED,
+          })}
+        >
+          {renderer
+            ? renderer(wordDiff.value as string, renderContext)
+            : wordDiff.value}
+        </span>
+      );
+    });
+  };
 
-	/**
-	 * Maps over the line diff and constructs the required react elements to show line diff. It calls
-	 * renderWordDiff when encountering word diff. This takes care of both inline and split view line
-	 * renders.
-	 *
-	 * @param lineNumber Line number of the current line.
-	 * @param type Type of diff of the current line.
-	 * @param prefix Unique id to prefix with the line numbers.
-	 * @param value Content of the line. It can be a string or a word diff array.
-	 * @param additionalLineNumber Additional line number to be shown. Useful for rendering inline
-	 *  diff view. Right line number will be passed as additionalLineNumber.
-	 * @param additionalPrefix Similar to prefix but for additional line number.
-	 */
-	private renderLine = (
-		lineNumber: number,
-		type: DiffType,
-		prefix: LineNumberPrefix,
-		value: string | DiffInformation[],
-		additionalLineNumber?: number,
-		additionalPrefix?: LineNumberPrefix,
-	): JSX.Element => {
-		const lineNumberTemplate = `${prefix}-${lineNumber}`;
-		const additionalLineNumberTemplate = `${additionalPrefix}-${additionalLineNumber}`;
-		const highlightLine =
-			this.props.highlightLines.includes(lineNumberTemplate) ||
-			this.props.highlightLines.includes(additionalLineNumberTemplate);
-		const added = type === DiffType.ADDED;
-		const removed = type === DiffType.REMOVED;
-		let content;
-		if (Array.isArray(value)) {
-			content = this.renderWordDiff(value, this.props.renderContent);
-		} else if (this.props.renderContent) {
-			content = this.props.renderContent(value);
-		} else {
-			content = value;
-		}
+  /**
+   * Maps over the line diff and constructs the required react elements to show line diff. It calls
+   * renderWordDiff when encountering word diff. This takes care of both inline and split view line
+   * renders.
+   *
+   * @param lineNumber Line number of the current line.
+   * @param type Type of diff of the current line.
+   * @param prefix Unique id to prefix with the line numbers.
+   * @param value Content of the line. It can be a string or a word diff array.
+   * @param additionalLineNumber Additional line number to be shown. Useful for rendering inline
+   *  diff view. Right line number will be passed as additionalLineNumber.
+   * @param additionalPrefix Similar to prefix but for additional line number.
+   */
+  private renderLine = (
+    renderContext: ReactDiffViewerRenderContext
+  ): JSX.Element => {
+    const {
+      lineNumber,
+      type,
+      prefix,
+      value,
+      additionalLineNumber,
+      additionalPrefix,
+    } = renderContext;
+    const lineNumberTemplate = `${prefix}-${lineNumber}`;
+    const additionalLineNumberTemplate = `${additionalPrefix}-${additionalLineNumber}`;
+    const highlightLine =
+      this.props.highlightLines.includes(lineNumberTemplate) ||
+      this.props.highlightLines.includes(additionalLineNumberTemplate);
+    const added = type === DiffType.ADDED;
+    const removed = type === DiffType.REMOVED;
+    let content;
+    if (Array.isArray(value)) {
+      content = this.renderWordDiff(value, this.props.renderContent);
+    } else if (this.props.renderContent) {
+      content = this.props.renderContent(value, renderContext);
+    } else {
+      content = value;
+    }
 
-		return (
-			<React.Fragment>
-				{!this.props.hideLineNumbers && (
-					<td
-						onClick={
-							lineNumber && this.onLineNumberClickProxy(lineNumberTemplate)
-						}
-						className={cn(this.styles.gutter, {
-							[this.styles.emptyGutter]: !lineNumber,
-							[this.styles.diffAdded]: added,
-							[this.styles.diffRemoved]: removed,
-							[this.styles.highlightedGutter]: highlightLine,
-						})}>
-						<pre className={this.styles.lineNumber}>{lineNumber}</pre>
-					</td>
-				)}
-				{!this.props.splitView && !this.props.hideLineNumbers && (
-					<td
-						onClick={
-							additionalLineNumber &&
-							this.onLineNumberClickProxy(additionalLineNumberTemplate)
-						}
-						className={cn(this.styles.gutter, {
-							[this.styles.emptyGutter]: !additionalLineNumber,
-							[this.styles.diffAdded]: added,
-							[this.styles.diffRemoved]: removed,
-							[this.styles.highlightedGutter]: highlightLine,
-						})}>
-						<pre className={this.styles.lineNumber}>{additionalLineNumber}</pre>
-					</td>
-				)}
-				<td
-					className={cn(this.styles.marker, {
-						[this.styles.emptyLine]: !content,
-						[this.styles.diffAdded]: added,
-						[this.styles.diffRemoved]: removed,
-						[this.styles.highlightedLine]: highlightLine,
-					})}>
-					<pre>
-						{added && '+'}
-						{removed && '-'}
-					</pre>
-				</td>
-				<td
-					className={cn(this.styles.content, {
-						[this.styles.emptyLine]: !content,
-						[this.styles.diffAdded]: added,
-						[this.styles.diffRemoved]: removed,
-						[this.styles.highlightedLine]: highlightLine,
-					})}>
-					<pre className={this.styles.contentText}>{content}</pre>
-				</td>
-			</React.Fragment>
-		);
-	};
+    return (
+      <React.Fragment>
+        {!this.props.hideLineNumbers && (
+          <td
+            onClick={
+              lineNumber && this.onLineNumberClickProxy(lineNumberTemplate)
+            }
+            className={cn(this.styles.gutter, {
+              [this.styles.emptyGutter]: !lineNumber,
+              [this.styles.diffAdded]: added,
+              [this.styles.diffRemoved]: removed,
+              [this.styles.highlightedGutter]: highlightLine,
+            })}
+          >
+            <pre className={this.styles.lineNumber}>{lineNumber}</pre>
+          </td>
+        )}
+        {!this.props.splitView && !this.props.hideLineNumbers && (
+          <td
+            onClick={
+              additionalLineNumber &&
+              this.onLineNumberClickProxy(additionalLineNumberTemplate)
+            }
+            className={cn(this.styles.gutter, {
+              [this.styles.emptyGutter]: !additionalLineNumber,
+              [this.styles.diffAdded]: added,
+              [this.styles.diffRemoved]: removed,
+              [this.styles.highlightedGutter]: highlightLine,
+            })}
+          >
+            <pre className={this.styles.lineNumber}>{additionalLineNumber}</pre>
+          </td>
+        )}
+        <td
+          className={cn(this.styles.marker, {
+            [this.styles.emptyLine]: !content,
+            [this.styles.diffAdded]: added,
+            [this.styles.diffRemoved]: removed,
+            [this.styles.highlightedLine]: highlightLine,
+          })}
+        >
+          <pre>
+            {added && "+"}
+            {removed && "-"}
+          </pre>
+        </td>
+        <td
+          className={cn(this.styles.content, {
+            [this.styles.emptyLine]: !content,
+            [this.styles.diffAdded]: added,
+            [this.styles.diffRemoved]: removed,
+            [this.styles.highlightedLine]: highlightLine,
+          })}
+        >
+          <pre className={this.styles.contentText}>{content}</pre>
+        </td>
+      </React.Fragment>
+    );
+  };
 
-	/**
-	 * Generates lines for split view.
-	 *
-	 * @param obj Line diff information.
-	 * @param obj.left Life diff information for the left pane of the split view.
-	 * @param obj.right Life diff information for the right pane of the split view.
-	 * @param index React key for the lines.
-	 */
-	private renderSplitView = (
-		{ left, right }: LineInformation,
-		index: number,
-	): JSX.Element => {
-		return (
-			<tr key={index} className={this.styles.line}>
-				{this.renderLine(
-					left.lineNumber,
-					left.type,
-					LineNumberPrefix.LEFT,
-					left.value,
-				)}
-				{this.renderLine(
-					right.lineNumber,
-					right.type,
-					LineNumberPrefix.RIGHT,
-					right.value,
-				)}
-			</tr>
-		);
-	};
+  /**
+   * Generates lines for split view.
+   *
+   * @param obj Line diff information.
+   * @param obj.left Life diff information for the left pane of the split view.
+   * @param obj.right Life diff information for the right pane of the split view.
+   * @param index React key for the lines.
+   */
+  private renderSplitView = (
+    { left, right }: LineInformation,
+    index: number
+  ): JSX.Element => {
+    return (
+      <tr key={index} className={this.styles.line}>
+        {this.renderLine({
+          lineNumber: left.lineNumber,
+          type: left.type,
+          prefix: LineNumberPrefix.LEFT,
+          value: left.value,
+        })}
+        {this.renderLine({
+          lineNumber: right.lineNumber,
+          type: right.type,
+          prefix: LineNumberPrefix.RIGHT,
+          value: right.value,
+        })}
+      </tr>
+    );
+  };
 
-	/**
-	 * Generates lines for inline view.
-	 *
-	 * @param obj Line diff information.
-	 * @param obj.left Life diff information for the added section of the inline view.
-	 * @param obj.right Life diff information for the removed section of the inline view.
-	 * @param index React key for the lines.
-	 */
-	public renderInlineView = (
-		{ left, right }: LineInformation,
-		index: number,
-	): JSX.Element => {
-		let content;
-		if (left.type === DiffType.REMOVED && right.type === DiffType.ADDED) {
-			return (
-				<React.Fragment key={index}>
-					<tr className={this.styles.line}>
-						{this.renderLine(
-							left.lineNumber,
-							left.type,
-							LineNumberPrefix.LEFT,
-							left.value,
-							null,
-						)}
-					</tr>
-					<tr className={this.styles.line}>
-						{this.renderLine(
-							null,
-							right.type,
-							LineNumberPrefix.RIGHT,
-							right.value,
-							right.lineNumber,
-						)}
-					</tr>
-				</React.Fragment>
-			);
-		}
-		if (left.type === DiffType.REMOVED) {
-			content = this.renderLine(
-				left.lineNumber,
-				left.type,
-				LineNumberPrefix.LEFT,
-				left.value,
-				null,
-			);
-		}
-		if (left.type === DiffType.DEFAULT) {
-			content = this.renderLine(
-				left.lineNumber,
-				left.type,
-				LineNumberPrefix.LEFT,
-				left.value,
-				right.lineNumber,
-				LineNumberPrefix.RIGHT,
-			);
-		}
-		if (right.type === DiffType.ADDED) {
-			content = this.renderLine(
-				null,
-				right.type,
-				LineNumberPrefix.RIGHT,
-				right.value,
-				right.lineNumber,
-			);
-		}
+  /**
+   * Generates lines for inline view.
+   *
+   * @param obj Line diff information.
+   * @param obj.left Life diff information for the added section of the inline view.
+   * @param obj.right Life diff information for the removed section of the inline view.
+   * @param index React key for the lines.
+   */
+  public renderInlineView = (
+    { left, right }: LineInformation,
+    index: number
+  ): JSX.Element => {
+    let content;
+    if (left.type === DiffType.REMOVED && right.type === DiffType.ADDED) {
+      return (
+        <React.Fragment key={index}>
+          <tr className={this.styles.line}>
+            {this.renderLine({
+              lineNumber: left.lineNumber,
+              type: left.type,
+              prefix: LineNumberPrefix.LEFT,
+              value: left.value,
+            })}
+          </tr>
+          <tr className={this.styles.line}>
+            {this.renderLine({
+              lineNumber: null,
+              type: right.type,
+              prefix: LineNumberPrefix.RIGHT,
+              value: right.value,
+              additionalLineNumber: right.lineNumber,
+            })}
+          </tr>
+        </React.Fragment>
+      );
+    }
+    if (left.type === DiffType.REMOVED) {
+      content = this.renderLine({
+        lineNumber: left.lineNumber,
+        type: left.type,
+        prefix: LineNumberPrefix.LEFT,
+        value: left.value,
+      });
+    }
+    if (left.type === DiffType.DEFAULT) {
+      content = this.renderLine({
+        lineNumber: left.lineNumber,
+        type: left.type,
+        prefix: LineNumberPrefix.LEFT,
+        value: left.value,
+        additionalLineNumber: right.lineNumber,
+        additionalPrefix: LineNumberPrefix.RIGHT,
+      });
+    }
+    if (right.type === DiffType.ADDED) {
+      content = this.renderLine({
+        lineNumber: null,
+        type: right.type,
+        prefix: LineNumberPrefix.RIGHT,
+        value: right.value,
+        additionalLineNumber: right.lineNumber,
+      });
+    }
 
-		return (
-			<tr key={index} className={this.styles.line}>
-				{content}
-			</tr>
-		);
-	};
+    return (
+      <tr key={index} className={this.styles.line}>
+        {content}
+      </tr>
+    );
+  };
 
-	/**
-	 * Returns a function with clicked block number in the closure.
-	 *
-	 * @param id Cold fold block id.
-	 */
-	private onBlockClickProxy = (id: number): any => (): void =>
-		this.onBlockExpand(id);
+  /**
+   * Returns a function with clicked block number in the closure.
+   *
+   * @param id Cold fold block id.
+   */
+  private onBlockClickProxy =
+    (id: number): any =>
+    (): void =>
+      this.onBlockExpand(id);
 
-	/**
-	 * Generates cold fold block. It also uses the custom message renderer when available to show
-	 * cold fold messages.
-	 *
-	 * @param num Number of skipped lines between two blocks.
-	 * @param blockNumber Code fold block id.
-	 * @param leftBlockLineNumber First left line number after the current code fold block.
-	 * @param rightBlockLineNumber First right line number after the current code fold block.
-	 */
-	private renderSkippedLineIndicator = (
-		num: number,
-		blockNumber: number,
-		leftBlockLineNumber: number,
-		rightBlockLineNumber: number,
-	): JSX.Element => {
-		const { hideLineNumbers, splitView } = this.props;
-		const message = this.props.codeFoldMessageRenderer ? (
-			this.props.codeFoldMessageRenderer(
-				num,
-				leftBlockLineNumber,
-				rightBlockLineNumber,
-			)
-		) : (
-			<pre className={this.styles.codeFoldContent}>Expand {num} lines ...</pre>
-		);
-		const content = (
-			<td>
-				<a onClick={this.onBlockClickProxy(blockNumber)} tabIndex={0}>
-					{message}
-				</a>
-			</td>
-		);
-		const isUnifiedViewWithoutLineNumbers = !splitView && !hideLineNumbers;
-		return (
-			<tr
-				key={`${leftBlockLineNumber}-${rightBlockLineNumber}`}
-				className={this.styles.codeFold}>
-				{!hideLineNumbers && <td className={this.styles.codeFoldGutter} />}
-				<td
-					className={cn({
-						[this.styles.codeFoldGutter]: isUnifiedViewWithoutLineNumbers,
-					})}
-				/>
+  /**
+   * Generates cold fold block. It also uses the custom message renderer when available to show
+   * cold fold messages.
+   *
+   * @param num Number of skipped lines between two blocks.
+   * @param blockNumber Code fold block id.
+   * @param leftBlockLineNumber First left line number after the current code fold block.
+   * @param rightBlockLineNumber First right line number after the current code fold block.
+   */
+  private renderSkippedLineIndicator = (
+    num: number,
+    blockNumber: number,
+    leftBlockLineNumber: number,
+    rightBlockLineNumber: number
+  ): JSX.Element => {
+    const { hideLineNumbers, splitView } = this.props;
+    const message = this.props.codeFoldMessageRenderer ? (
+      this.props.codeFoldMessageRenderer(
+        num,
+        leftBlockLineNumber,
+        rightBlockLineNumber
+      )
+    ) : (
+      <pre className={this.styles.codeFoldContent}>Expand {num} lines ...</pre>
+    );
+    const content = (
+      <td>
+        <a onClick={this.onBlockClickProxy(blockNumber)} tabIndex={0}>
+          {message}
+        </a>
+      </td>
+    );
+    const isUnifiedViewWithoutLineNumbers = !splitView && !hideLineNumbers;
+    return (
+      <tr
+        key={`${leftBlockLineNumber}-${rightBlockLineNumber}`}
+        className={this.styles.codeFold}
+      >
+        {!hideLineNumbers && <td className={this.styles.codeFoldGutter} />}
+        <td
+          className={cn({
+            [this.styles.codeFoldGutter]: isUnifiedViewWithoutLineNumbers,
+          })}
+        />
 
-				{/* Swap columns only for unified view without line numbers */}
-				{isUnifiedViewWithoutLineNumbers ? (
-					<React.Fragment>
-						<td />
-						{content}
-					</React.Fragment>
-				) : (
-					<React.Fragment>
-						{content}
-						<td />
-					</React.Fragment>
-				)}
+        {/* Swap columns only for unified view without line numbers */}
+        {isUnifiedViewWithoutLineNumbers ? (
+          <React.Fragment>
+            <td />
+            {content}
+          </React.Fragment>
+        ) : (
+          <React.Fragment>
+            {content}
+            <td />
+          </React.Fragment>
+        )}
 
-				<td />
-				<td />
-			</tr>
-		);
-	};
+        <td />
+        <td />
+      </tr>
+    );
+  };
 
-	/**
-	 * Generates the entire diff view.
-	 */
-	private renderDiff = (): JSX.Element[] => {
-		const {
-			oldValue,
-			newValue,
-			splitView,
-			disableWordDiff,
-			compareMethod,
-			linesOffset,
-		} = this.props;
-		const { lineInformation, diffLines } = computeLineInformation(
-			oldValue,
-			newValue,
-			disableWordDiff,
-			compareMethod,
-			linesOffset,
-		);
-		const extraLines =
-			this.props.extraLinesSurroundingDiff < 0
-				? 0
-				: this.props.extraLinesSurroundingDiff;
-		let skippedLines: number[] = [];
-		return lineInformation.map(
-			(line: LineInformation, i: number): JSX.Element => {
-				const diffBlockStart = diffLines[0];
-				const currentPosition = diffBlockStart - i;
-				if (this.props.showDiffOnly) {
-					if (currentPosition === -extraLines) {
-						skippedLines = [];
-						diffLines.shift();
-					}
-					if (
-						line.left.type === DiffType.DEFAULT &&
-						(currentPosition > extraLines ||
-							typeof diffBlockStart === 'undefined') &&
-						!this.state.expandedBlocks.includes(diffBlockStart)
-					) {
-						skippedLines.push(i + 1);
-						if (i === lineInformation.length - 1 && skippedLines.length > 1) {
-							return this.renderSkippedLineIndicator(
-								skippedLines.length,
-								diffBlockStart,
-								line.left.lineNumber,
-								line.right.lineNumber,
-							);
-						}
-						return null;
-					}
-				}
+  /**
+   * Generates the entire diff view.
+   */
+  private renderDiff = (): JSX.Element[] => {
+    const {
+      oldValue,
+      newValue,
+      splitView,
+      disableWordDiff,
+      compareMethod,
+      linesOffset,
+    } = this.props;
+    const { lineInformation, diffLines } = computeLineInformation(
+      oldValue,
+      newValue,
+      disableWordDiff,
+      compareMethod,
+      linesOffset
+    );
+    const extraLines =
+      this.props.extraLinesSurroundingDiff < 0
+        ? 0
+        : this.props.extraLinesSurroundingDiff;
+    let skippedLines: number[] = [];
+    return lineInformation.map(
+      (line: LineInformation, i: number): JSX.Element => {
+        const diffBlockStart = diffLines[0];
+        const currentPosition = diffBlockStart - i;
+        if (this.props.showDiffOnly) {
+          if (currentPosition === -extraLines) {
+            skippedLines = [];
+            diffLines.shift();
+          }
+          if (
+            line.left.type === DiffType.DEFAULT &&
+            (currentPosition > extraLines ||
+              typeof diffBlockStart === "undefined") &&
+            !this.state.expandedBlocks.includes(diffBlockStart)
+          ) {
+            skippedLines.push(i + 1);
+            if (i === lineInformation.length - 1 && skippedLines.length > 1) {
+              return this.renderSkippedLineIndicator(
+                skippedLines.length,
+                diffBlockStart,
+                line.left.lineNumber,
+                line.right.lineNumber
+              );
+            }
+            return null;
+          }
+        }
 
-				const diffNodes = splitView
-					? this.renderSplitView(line, i)
-					: this.renderInlineView(line, i);
+        const diffNodes = splitView
+          ? this.renderSplitView(line, i)
+          : this.renderInlineView(line, i);
 
-				if (currentPosition === extraLines && skippedLines.length > 0) {
-					const { length } = skippedLines;
-					skippedLines = [];
-					return (
-						<React.Fragment key={i}>
-							{this.renderSkippedLineIndicator(
-								length,
-								diffBlockStart,
-								line.left.lineNumber,
-								line.right.lineNumber,
-							)}
-							{diffNodes}
-						</React.Fragment>
-					);
-				}
-				return diffNodes;
-			},
-		);
-	};
+        if (currentPosition === extraLines && skippedLines.length > 0) {
+          const { length } = skippedLines;
+          skippedLines = [];
+          return (
+            <React.Fragment key={i}>
+              {this.renderSkippedLineIndicator(
+                length,
+                diffBlockStart,
+                line.left.lineNumber,
+                line.right.lineNumber
+              )}
+              {diffNodes}
+            </React.Fragment>
+          );
+        }
+        return diffNodes;
+      }
+    );
+  };
 
-	public render = (): JSX.Element => {
-		const {
-			oldValue,
-			newValue,
-			useDarkTheme,
-			leftTitle,
-			rightTitle,
-			splitView,
-			hideLineNumbers,
-		} = this.props;
+  public render = (): JSX.Element => {
+    const {
+      oldValue,
+      newValue,
+      useDarkTheme,
+      leftTitle,
+      rightTitle,
+      splitView,
+      hideLineNumbers,
+    } = this.props;
 
-		if (typeof oldValue !== 'string' || typeof newValue !== 'string') {
-			throw Error('"oldValue" and "newValue" should be strings');
-		}
+    if (typeof oldValue !== "string" || typeof newValue !== "string") {
+      throw Error('"oldValue" and "newValue" should be strings');
+    }
 
-		this.styles = this.computeStyles(this.props.styles, useDarkTheme);
-		const nodes = this.renderDiff();
-		const colSpanOnSplitView = hideLineNumbers ? 2 : 3;
-		const colSpanOnInlineView = hideLineNumbers ? 2 : 4;
+    this.styles = this.computeStyles(this.props.styles, useDarkTheme);
+    const nodes = this.renderDiff();
+    const colSpanOnSplitView = hideLineNumbers ? 2 : 3;
+    const colSpanOnInlineView = hideLineNumbers ? 2 : 4;
 
-		const title = (leftTitle || rightTitle) && (
-			<tr>
-				<td
-					colSpan={splitView ? colSpanOnSplitView : colSpanOnInlineView}
-					className={this.styles.titleBlock}>
-					<pre className={this.styles.contentText}>{leftTitle}</pre>
-				</td>
-				{splitView && (
-					<td colSpan={colSpanOnSplitView} className={this.styles.titleBlock}>
-						<pre className={this.styles.contentText}>{rightTitle}</pre>
-					</td>
-				)}
-			</tr>
-		);
+    const title = (leftTitle || rightTitle) && (
+      <tr>
+        <td
+          colSpan={splitView ? colSpanOnSplitView : colSpanOnInlineView}
+          className={this.styles.titleBlock}
+        >
+          <pre className={this.styles.contentText}>{leftTitle}</pre>
+        </td>
+        {splitView && (
+          <td colSpan={colSpanOnSplitView} className={this.styles.titleBlock}>
+            <pre className={this.styles.contentText}>{rightTitle}</pre>
+          </td>
+        )}
+      </tr>
+    );
 
-		return (
-			<table
-				className={cn(this.styles.diffContainer, {
-					[this.styles.splitView]: splitView,
-				})}>
-				<tbody>
-					{title}
-					{nodes}
-				</tbody>
-			</table>
-		);
-	};
+    return (
+      <table
+        className={cn(this.styles.diffContainer, {
+          [this.styles.splitView]: splitView,
+        })}
+      >
+        <tbody>
+          {title}
+          {nodes}
+        </tbody>
+      </table>
+    );
+  };
 }
 
 export default DiffViewer;

--- a/yarn.lock
+++ b/yarn.lock
@@ -229,11 +229,6 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
-"@types/minimist@^1.2.0":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
-  integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
-
 "@types/mocha@^5.2.5":
   version "5.2.7"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-5.2.7.tgz#315d570ccb56c53452ff8638738df60726d5b6ea"
@@ -243,11 +238,6 @@
   version "12.0.12"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.12.tgz#cc791b402360db1eaf7176479072f91ee6c6c7ca"
   integrity sha512-Uy0PN4R5vgBUXFoJrKryf5aTk3kJ8Rv3PdlHjl6UaX+Cqp1QE0yPQ68MPXGrZOfG7gZVNDIJZYyot0B9ubXUrQ==
-
-"@types/normalize-package-data@^2.4.0":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"
-  integrity sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==
 
 "@types/prop-types@*":
   version "15.7.1"
@@ -599,10 +589,10 @@ ansi-regex@^4.0.0, ansi-regex@^4.1.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
   integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
-ansi-regex@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
-  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+ansi-styles@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
+  integrity sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==
 
 ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
@@ -610,13 +600,6 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
   dependencies:
     color-convert "^1.9.0"
-
-ansi-styles@^4.1.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
-  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
-  dependencies:
-    color-convert "^2.0.1"
 
 anymatch@^2.0.0:
   version "2.0.0"
@@ -630,19 +613,6 @@ aproba@^1.0.3, aproba@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
   integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
-
-"aproba@^1.0.3 || ^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/aproba/-/aproba-2.0.0.tgz#52520b8ae5b569215b354efc0caa3fe1e45a8adc"
-  integrity sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==
-
-are-we-there-yet@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz#372e0e7bd279d8e94c653aaa1f67200884bf3e1c"
-  integrity sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==
-  dependencies:
-    delegates "^1.0.0"
-    readable-stream "^3.6.0"
 
 are-we-there-yet@~1.1.2:
   version "1.1.5"
@@ -691,6 +661,11 @@ array-filter@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-filter/-/array-filter-1.0.0.tgz#baf79e62e6ef4c2a4c0b831232daffec251f9d83"
   integrity sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=
+
+array-find-index@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
+  integrity sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==
 
 array-flatten@1.1.1:
   version "1.1.1"
@@ -926,6 +901,13 @@ binary-extensions@^1.0.0:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"
   integrity sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==
+
+block-stream@*:
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
+  integrity sha512-OorbnJVPII4DuUKbjARAe8u8EfqOmkEEaSFIyoQ7OjTHn6kafxWl0wLgoZ2rXaYd7MyLcDaU4TmhfxtwgcccMQ==
+  dependencies:
+    inherits "~2.0.0"
 
 bluebird@^3.5.5:
   version "3.5.5"
@@ -1209,16 +1191,15 @@ camel-case@3.0.x:
     no-case "^2.2.0"
     upper-case "^1.1.1"
 
-camelcase-keys@^6.2.2:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-6.2.2.tgz#5e755d6ba51aa223ec7d3d52f25778210f9dc3c0"
-  integrity sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==
+camelcase-keys@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-2.1.0.tgz#308beeaffdf28119051efa1d932213c91b8f92e7"
+  integrity sha512-bA/Z/DERHKqoEOrp+qeGKw1QlvEQkGZSc0XaY6VnTxZr+Kv1G5zFwttpjv8qxZ/sBPT4nthwZaAcsAZTJlSKXQ==
   dependencies:
-    camelcase "^5.3.1"
-    map-obj "^4.0.0"
-    quick-lru "^4.0.1"
+    camelcase "^2.0.0"
+    map-obj "^1.0.0"
 
-camelcase@^2.0.1:
+camelcase@^2.0.0, camelcase@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
   integrity sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=
@@ -1242,13 +1223,16 @@ chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.4.
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
-  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+chalk@^1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
+  integrity sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==
   dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
+    ansi-styles "^2.2.1"
+    escape-string-regexp "^1.0.2"
+    has-ansi "^2.0.0"
+    strip-ansi "^3.0.0"
+    supports-color "^2.0.0"
 
 chardet@^0.7.0:
   version "0.7.0"
@@ -1301,11 +1285,6 @@ chownr@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.2.tgz#a18f1e0b269c8a6a5d3c86eb298beb14c3dd7bf6"
   integrity sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A==
-
-chownr@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
-  integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
 chrome-trace-event@^1.0.0:
   version "1.0.2"
@@ -1423,27 +1402,10 @@ color-convert@^1.9.0:
   dependencies:
     color-name "1.1.3"
 
-color-convert@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
-  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
-  dependencies:
-    color-name "~1.1.4"
-
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
-
-color-name@~1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
-  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
-
-color-support@^1.1.2:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
-  integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
 
 colors@^1.1.2:
   version "1.3.3"
@@ -1534,7 +1496,7 @@ console-browserify@^1.1.0:
   dependencies:
     date-now "^0.1.4"
 
-console-control-strings@^1.0.0, console-control-strings@^1.1.0, console-control-strings@~1.1.0:
+console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
@@ -1662,14 +1624,13 @@ cross-spawn@6.0.5, cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
-  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
+cross-spawn@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-3.0.1.tgz#1256037ecb9f0c5f79e3d6ef135e30770184b982"
+  integrity sha512-eZ+m1WNhSZutOa/uRblAc9Ut5MQfukFrFMtPSm3bZCA888NmMd5AWXWdgRZ80zd+pTk1P2JrGjg9pUPTvl2PWQ==
   dependencies:
-    path-key "^3.1.0"
-    shebang-command "^2.0.0"
-    which "^2.0.1"
+    lru-cache "^4.0.1"
+    which "^1.2.9"
 
 crypto-browserify@^3.11.0:
   version "3.12.0"
@@ -1746,6 +1707,13 @@ csstype@^2.2.0, csstype@^2.5.7:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.5.tgz#1cd1dff742ebf4d7c991470ae71e12bb6751e034"
   integrity sha512-JsTaiksRsel5n7XwqPAfB0l3TFKdpjW/kgAELf9vrb5adGA7UCPLajKK5s3nFrcFm3Rkyp/Qkgl73ENc1UY3cA==
 
+currently-unhandled@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
+  integrity sha512-/fITjgjGU50vjQ4FH6eUoYu+iUoUKIXws2hL15JJpIR+BbTxaXQsMuuyjtNh2WqsSBS5nsaZHFsFecyw5CCAng==
+  dependencies:
+    array-find-index "^1.0.1"
+
 cyclist@~0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
@@ -1796,15 +1764,7 @@ debug@~2.2.0:
   dependencies:
     ms "0.7.1"
 
-decamelize-keys@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/decamelize-keys/-/decamelize-keys-1.1.0.tgz#d171a87933252807eb3cb61dc1c1445d078df2d9"
-  integrity sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=
-  dependencies:
-    decamelize "^1.1.0"
-    map-obj "^1.0.0"
-
-decamelize@^1.1.0, decamelize@^1.1.1, decamelize@^1.2.0:
+decamelize@^1.1.1, decamelize@^1.1.2, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
@@ -2106,11 +2066,6 @@ emoji-regex@^7.0.1, emoji-regex@^7.0.2:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
   integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
 
-emoji-regex@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
-  integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
-
 emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
@@ -2154,11 +2109,6 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
   integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
-
-env-paths@^2.2.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.1.tgz#420399d416ce1fbe9bc0a07c62fa68d67fd0f8f2"
-  integrity sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==
 
 enzyme-adapter-react-16@^1.6.0:
   version "1.14.0"
@@ -2802,20 +2752,20 @@ find-up@3.0.0, find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
+find-up@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
+  integrity sha512-jvElSjyuo4EMQGoTwo1uJU5pQMwTW5lS1x05zzfJuTIyLR3zwO27LYrxNg+dlvKpGOuGy/MzBdXh80g0ve5+HA==
+  dependencies:
+    path-exists "^2.0.0"
+    pinkie-promise "^2.0.0"
+
 find-up@^2.0.0, find-up@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
   integrity sha1-RdG35QbHF93UgndaK3eSCjwMV6c=
   dependencies:
     locate-path "^2.0.0"
-
-find-up@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
-  integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
-  dependencies:
-    locate-path "^5.0.0"
-    path-exists "^4.0.0"
 
 findup-sync@3.0.0:
   version "3.0.0"
@@ -2949,13 +2899,6 @@ fs-minipass@^1.2.5:
   dependencies:
     minipass "^2.2.1"
 
-fs-minipass@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
-  integrity sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==
-  dependencies:
-    minipass "^3.0.0"
-
 fs-write-stream-atomic@^1.0.8:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz#b47df53493ef911df75731e70a9ded0189db40c9"
@@ -2979,6 +2922,16 @@ fsevents@^1.2.7:
     nan "^2.12.1"
     node-pre-gyp "^0.12.0"
 
+fstream@^1.0.0, fstream@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.12.tgz#4e8ba8ee2d48be4f7d0de505455548eae5932045"
+  integrity sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==
+  dependencies:
+    graceful-fs "^4.1.2"
+    inherits "~2.0.0"
+    mkdirp ">=0.5 0"
+    rimraf "2"
+
 function-bind@^1.0.2, function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
@@ -2997,21 +2950,6 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
-
-gauge@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/gauge/-/gauge-3.0.2.tgz#03bf4441c044383908bcfa0656ad91803259b395"
-  integrity sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==
-  dependencies:
-    aproba "^1.0.3 || ^2.0.0"
-    color-support "^1.1.2"
-    console-control-strings "^1.0.0"
-    has-unicode "^2.0.1"
-    object-assign "^4.1.1"
-    signal-exit "^3.0.0"
-    string-width "^4.2.3"
-    strip-ansi "^6.0.1"
-    wide-align "^1.1.2"
 
 gauge@~2.7.3:
   version "2.7.4"
@@ -3196,11 +3134,6 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.0.tgz#8d8fdc73977cb04104721cb53666c1ca64cd328b"
   integrity sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==
 
-graceful-fs@^4.2.3:
-  version "4.2.10"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
-  integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
-
 growl@1.10.5:
   version "1.10.5"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
@@ -3224,32 +3157,29 @@ har-validator@~5.1.3:
     ajv "^6.12.3"
     har-schema "^2.0.0"
 
-hard-rejection@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/hard-rejection/-/hard-rejection-2.1.0.tgz#1c6eda5c1685c63942766d79bb40ae773cecd883"
-  integrity sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==
-
 harmony-reflect@^1.4.2:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/harmony-reflect/-/harmony-reflect-1.6.1.tgz#c108d4f2bb451efef7a37861fdbdae72c9bdefa9"
   integrity sha512-WJTeyp0JzGtHcuMsi7rw2VwtkvLa+JyfEKJCFyfcS0+CDkjQ5lHPu7zEhFZP+PDSRrEgXa5Ah0l1MbgbE41XjA==
+
+has-ansi@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
+  integrity sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==
+  dependencies:
+    ansi-regex "^2.0.0"
 
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
 
-has-flag@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
-  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
-
 has-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
   integrity sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=
 
-has-unicode@^2.0.0, has-unicode@^2.0.1:
+has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
   integrity sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=
@@ -3341,13 +3271,6 @@ hosted-git-info@^2.1.4:
   version "2.8.9"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
   integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
-
-hosted-git-info@^4.0.1:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-4.1.0.tgz#827b82867e9ff1c8d0c4d9d53880397d2c86d224"
-  integrity sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==
-  dependencies:
-    lru-cache "^6.0.0"
 
 hpack.js@^2.1.6:
   version "2.1.6"
@@ -3578,10 +3501,17 @@ imurmurhash@^0.1.4:
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
 
-indent-string@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
-  integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
+in-publish@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/in-publish/-/in-publish-2.0.1.tgz#948b1a535c8030561cea522f73f78f4be357e00c"
+  integrity sha512-oDM0kUSNFC31ShNxHKUyfZKy8ZeXZBWMjMdZHKLOk13uvT27VTL/QzRGfRUcevJhpkZAvlhPYuXkF7eNWrtyxQ==
+
+indent-string@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-2.1.0.tgz#8e2d48348742121b4a8218b7a137e9a52049dc80"
+  integrity sha512-aqwDFWSgSgfRaEwao5lg5KEcVd/2a+D1rvoG7NdilmYz0NwRk6StWpWdz/Hpk34MKPpx7s8XxUqimfcQK6gGlg==
+  dependencies:
+    repeating "^2.0.0"
 
 indexes-of@^1.0.1:
   version "1.0.1"
@@ -3596,7 +3526,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -3724,13 +3654,6 @@ is-callable@^1.1.3, is-callable@^1.1.4:
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
   integrity sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==
 
-is-core-module@^2.5.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.9.0.tgz#e1c34429cd51c6dd9e09e0799e396e27b19a9c69"
-  integrity sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==
-  dependencies:
-    has "^1.0.3"
-
 is-data-descriptor@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
@@ -3790,6 +3713,11 @@ is-extglob@^2.1.0, is-extglob@^2.1.1:
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
   integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
 
+is-finite@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-finite/-/is-finite-1.1.0.tgz#904135c77fb42c0641d6aa1bcdbc4daa8da082f3"
+  integrity sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==
+
 is-fullwidth-code-point@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
@@ -3801,11 +3729,6 @@ is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
   integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
-
-is-fullwidth-code-point@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
-  integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
 is-function@^1.0.1:
   version "1.0.1"
@@ -3862,7 +3785,7 @@ is-path-inside@^2.1.0:
   dependencies:
     path-is-inside "^1.0.2"
 
-is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
+is-plain-obj@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
@@ -3912,6 +3835,11 @@ is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
+
+is-utf8@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
+  integrity sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==
 
 is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
@@ -4059,11 +3987,6 @@ json-parse-better-errors@^1.0.1, json-parse-better-errors@^1.0.2:
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
   integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
 
-json-parse-even-better-errors@^2.3.0:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
-  integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
-
 json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
@@ -4172,11 +4095,6 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
   integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
 
-kind-of@^6.0.3:
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
-  integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
-
 klaw@^1.0.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/klaw/-/klaw-1.3.1.tgz#4088433b46b3b1ba259d78785d8e96f73ba02439"
@@ -4206,11 +4124,6 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-lines-and-columns@^1.1.6:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
-  integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
-
 load-bmfont@^1.2.3:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/load-bmfont/-/load-bmfont-1.4.0.tgz#75f17070b14a8c785fe7f5bee2e6fd4f98093b6b"
@@ -4224,6 +4137,17 @@ load-bmfont@^1.2.3:
     phin "^2.9.1"
     xhr "^2.0.1"
     xtend "^4.0.0"
+
+load-json-file@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
+  integrity sha512-cy7ZdNRXdablkXYNI049pthVeXFurRyb9+hA/dZzerZ0pGTx42z+y+ssxBaVV2l70t1muq5IdKhn4UtcoGUY9A==
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^2.2.0"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
+    strip-bom "^2.0.0"
 
 load-json-file@^2.0.0:
   version "2.0.0"
@@ -4274,13 +4198,6 @@ locate-path@^3.0.0:
   dependencies:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
-
-locate-path@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
-  integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
-  dependencies:
-    p-locate "^4.1.0"
 
 lodash.escape@^4.0.1:
   version "4.0.1"
@@ -4336,10 +4253,26 @@ loose-envify@^1.1.0, loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
+loud-rejection@^1.0.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/loud-rejection/-/loud-rejection-1.6.0.tgz#5b46f80147edee578870f086d04821cf998e551f"
+  integrity sha512-RPNliZOFkqFumDhvYqOaNY4Uz9oJM2K9tC6JWsJJsNdhuONW4LQHRBpb0qf4pJApVffI5N39SwzWZJuEhfd7eQ==
+  dependencies:
+    currently-unhandled "^0.4.1"
+    signal-exit "^3.0.0"
+
 lower-case@^1.1.1:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-1.1.4.tgz#9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac"
   integrity sha1-miyr0bno4K6ZOkv31YdcOcQujqw=
+
+lru-cache@^4.0.1:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
+  integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
 
 lru-cache@^5.1.1:
   version "5.1.1"
@@ -4347,13 +4280,6 @@ lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
-
-lru-cache@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
-  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
-  dependencies:
-    yallist "^4.0.0"
 
 make-dir@^2.0.0:
   version "2.1.0"
@@ -4385,15 +4311,10 @@ map-cache@^0.2.2:
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
   integrity sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=
 
-map-obj@^1.0.0:
+map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
   integrity sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=
-
-map-obj@^4.0.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-4.3.0.tgz#9304f906e93faae70880da102a9f1df0ea8bb05a"
-  integrity sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==
 
 map-visit@^1.0.0:
   version "1.0.0"
@@ -4438,23 +4359,21 @@ memory-fs@^0.4.0, memory-fs@^0.4.1, memory-fs@~0.4.1:
     errno "^0.1.3"
     readable-stream "^2.0.1"
 
-meow@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/meow/-/meow-9.0.0.tgz#cd9510bc5cac9dee7d03c73ee1f9ad959f4ea364"
-  integrity sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==
+meow@^3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
+  integrity sha512-TNdwZs0skRlpPpCUK25StC4VH+tP5GgeY1HQOOGP+lQ2xtdkN2VtT/5tiX9k3IWpkBPV9b3LsAWXn4GGi/PrSA==
   dependencies:
-    "@types/minimist" "^1.2.0"
-    camelcase-keys "^6.2.2"
-    decamelize "^1.2.0"
-    decamelize-keys "^1.1.0"
-    hard-rejection "^2.1.0"
-    minimist-options "4.1.0"
-    normalize-package-data "^3.0.0"
-    read-pkg-up "^7.0.1"
-    redent "^3.0.0"
-    trim-newlines "^3.0.0"
-    type-fest "^0.18.0"
-    yargs-parser "^20.2.3"
+    camelcase-keys "^2.0.0"
+    decamelize "^1.1.2"
+    loud-rejection "^1.0.0"
+    map-obj "^1.0.1"
+    minimist "^1.1.3"
+    normalize-package-data "^2.3.4"
+    object-assign "^4.0.1"
+    read-pkg-up "^1.0.1"
+    redent "^1.0.0"
+    trim-newlines "^1.0.0"
 
 merge-defaults@^0.2.1:
   version "0.2.2"
@@ -4547,11 +4466,6 @@ min-document@^2.19.0:
   dependencies:
     dom-walk "^0.1.0"
 
-min-indent@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
-  integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
-
 mini-css-extract-plugin@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-0.7.0.tgz#5ba8290fbb4179a43dd27cca444ba150bee743a0"
@@ -4579,19 +4493,15 @@ minimatch@3.0.4, minimatch@^3.0.4, minimatch@~3.0.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist-options@4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/minimist-options/-/minimist-options-4.1.0.tgz#c0655713c53a8a2ebd77ffa247d342c40f010619"
-  integrity sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==
-  dependencies:
-    arrify "^1.0.1"
-    is-plain-obj "^1.1.0"
-    kind-of "^6.0.3"
-
 minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
   integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
+
+minimist@^1.1.3, minimist@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 minimist@^1.2.0:
   version "1.2.0"
@@ -4606,27 +4516,12 @@ minipass@^2.2.1, minipass@^2.3.5:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
 
-minipass@^3.0.0:
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.6.tgz#3b8150aa688a711a1521af5e8779c1d3bb4f45ee"
-  integrity sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==
-  dependencies:
-    yallist "^4.0.0"
-
 minizlib@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.2.1.tgz#dd27ea6136243c7c880684e8672bb3a45fd9b614"
   integrity sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==
   dependencies:
     minipass "^2.2.1"
-
-minizlib@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
-  integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
-  dependencies:
-    minipass "^3.0.0"
-    yallist "^4.0.0"
 
 mississippi@^3.0.0:
   version "3.0.0"
@@ -4667,10 +4562,12 @@ mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
   dependencies:
     minimist "0.0.8"
 
-mkdirp@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
-  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+"mkdirp@>=0.5 0":
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
+  integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
+  dependencies:
+    minimist "^1.2.6"
 
 mocha@^6.1.4:
   version "6.1.4"
@@ -4838,21 +4735,23 @@ node-forge@0.7.5:
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.5.tgz#6c152c345ce11c52f465c2abd957e8639cd674df"
   integrity sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ==
 
-node-gyp@^7.1.0:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-7.1.2.tgz#21a810aebb187120251c3bcec979af1587b188ae"
-  integrity sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==
+node-gyp@^3.8.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-3.8.0.tgz#540304261c330e80d0d5edce253a68cb3964218c"
+  integrity sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==
   dependencies:
-    env-paths "^2.2.0"
-    glob "^7.1.4"
-    graceful-fs "^4.2.3"
-    nopt "^5.0.0"
-    npmlog "^4.1.2"
-    request "^2.88.2"
-    rimraf "^3.0.2"
-    semver "^7.3.2"
-    tar "^6.0.2"
-    which "^2.0.2"
+    fstream "^1.0.0"
+    glob "^7.0.3"
+    graceful-fs "^4.1.2"
+    mkdirp "^0.5.0"
+    nopt "2 || 3"
+    npmlog "0 || 1 || 2 || 3 || 4"
+    osenv "0"
+    request "^2.87.0"
+    rimraf "2"
+    semver "~5.3.0"
+    tar "^2.0.0"
+    which "1"
 
 node-libs-browser@^2.0.0:
   version "2.2.1"
@@ -4907,26 +4806,35 @@ node-rest-client@^1.5.1:
     debug "~2.2.0"
     xml2js ">=0.2.4"
 
-node-sass@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-7.0.0.tgz#33ee7c2df299d51f682f13d79f3d2a562225788e"
-  integrity sha512-6yUnsD3L8fVbgMX6nKQqZkjRcG7a/PpmF0pEyeWf+BgbTj2ToJlCYrnUifL2KbjV5gIY22I3oppahBWA3B+jUg==
+node-sass@^4.14:
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.14.1.tgz#99c87ec2efb7047ed638fb4c9db7f3a42e2217b5"
+  integrity sha512-sjCuOlvGyCJS40R8BscF5vhVlQjNN069NtQ1gSxyK1u9iqvn6tf7O1R4GNowVZfiZUCRt5MmMs1xd+4V/7Yr0g==
   dependencies:
     async-foreach "^0.1.3"
-    chalk "^4.1.2"
-    cross-spawn "^7.0.3"
+    chalk "^1.1.1"
+    cross-spawn "^3.0.0"
     gaze "^1.0.0"
     get-stdin "^4.0.1"
     glob "^7.0.3"
+    in-publish "^2.0.0"
     lodash "^4.17.15"
-    meow "^9.0.0"
+    meow "^3.7.0"
+    mkdirp "^0.5.1"
     nan "^2.13.2"
-    node-gyp "^7.1.0"
-    npmlog "^5.0.0"
+    node-gyp "^3.8.0"
+    npmlog "^4.0.0"
     request "^2.88.0"
     sass-graph "2.2.5"
     stdout-stream "^1.4.0"
     "true-case-path" "^1.0.2"
+
+"nopt@2 || 3":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
+  integrity sha512-4GUt3kSEYmk4ITxzB/b9vaIDfUVWN/Ml1Fwl11IlnIG2iaJ9O6WXZ9SrYM9NLI8OCBieN2Y8SWC2oJV0RQ7qYg==
+  dependencies:
+    abbrev "1"
 
 nopt@^4.0.1:
   version "4.0.1"
@@ -4936,14 +4844,7 @@ nopt@^4.0.1:
     abbrev "1"
     osenv "^0.1.4"
 
-nopt@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-5.0.0.tgz#530942bb58a512fccafe53fe210f13a25355dc88"
-  integrity sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==
-  dependencies:
-    abbrev "1"
-
-normalize-package-data@^2.3.2, normalize-package-data@^2.5.0:
+normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
   integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
@@ -4951,16 +4852,6 @@ normalize-package-data@^2.3.2, normalize-package-data@^2.5.0:
     hosted-git-info "^2.1.4"
     resolve "^1.10.0"
     semver "2 || 3 || 4 || 5"
-    validate-npm-package-license "^3.0.1"
-
-normalize-package-data@^3.0.0:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-3.0.3.tgz#dbcc3e2da59509a0983422884cd172eefdfa525e"
-  integrity sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==
-  dependencies:
-    hosted-git-info "^4.0.1"
-    is-core-module "^2.5.0"
-    semver "^7.3.4"
     validate-npm-package-license "^3.0.1"
 
 normalize-path@^2.1.1:
@@ -5005,7 +4896,7 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
-npmlog@^4.0.2, npmlog@^4.1.2:
+"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.0, npmlog@^4.0.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -5014,16 +4905,6 @@ npmlog@^4.0.2, npmlog@^4.1.2:
     console-control-strings "~1.1.0"
     gauge "~2.7.3"
     set-blocking "~2.0.0"
-
-npmlog@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-5.0.1.tgz#f06678e80e29419ad67ab964e0fa69959c1eb8b0"
-  integrity sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==
-  dependencies:
-    are-we-there-yet "^2.0.0"
-    console-control-strings "^1.1.0"
-    gauge "^3.0.0"
-    set-blocking "^2.0.0"
 
 nth-check@~1.0.0, nth-check@~1.0.1:
   version "1.0.2"
@@ -5221,7 +5102,7 @@ os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
-osenv@^0.1.4:
+osenv@0, osenv@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
   integrity sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==
@@ -5258,13 +5139,6 @@ p-limit@^2.0.0:
   dependencies:
     p-try "^2.0.0"
 
-p-limit@^2.2.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
-  integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
-  dependencies:
-    p-try "^2.0.0"
-
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
@@ -5278,13 +5152,6 @@ p-locate@^3.0.0:
   integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
   dependencies:
     p-limit "^2.0.0"
-
-p-locate@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-4.1.0.tgz#a3428bb7088b3a60292f66919278b7c297ad4f07"
-  integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
-  dependencies:
-    p-limit "^2.2.0"
 
 p-map@^2.0.0:
   version "2.1.0"
@@ -5389,16 +5256,6 @@ parse-json@^4.0.0:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
 
-parse-json@^5.0.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
-  integrity sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    error-ex "^1.3.1"
-    json-parse-even-better-errors "^2.3.0"
-    lines-and-columns "^1.1.6"
-
 parse-passwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
@@ -5438,15 +5295,17 @@ path-dirname@^1.0.0:
   resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
   integrity sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=
 
+path-exists@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
+  integrity sha512-yTltuKuhtNeFJKa1PiRzfLAU5182q1y4Eb4XCJ3PBqyzEDkAZRzBrKKBct682ls9reBVHf9udYLN5Nd+K1B9BQ==
+  dependencies:
+    pinkie-promise "^2.0.0"
+
 path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
   integrity sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=
-
-path-exists@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
-  integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
@@ -5463,11 +5322,6 @@ path-key@^2.0.0, path-key@^2.0.1:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
 
-path-key@^3.1.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
-  integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
-
 path-parse@^1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
@@ -5477,6 +5331,15 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
+
+path-type@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
+  integrity sha512-S4eENJz1pkiQn9Znv33Q+deTOKmbl+jj1Fl+qiP/vYezj+S8x+J3Uo0ISrx/QoEvIlOaDWJhPaRd1flJ9HXZqg==
+  dependencies:
+    graceful-fs "^4.1.2"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
 
 path-type@^2.0.0:
   version "2.0.0"
@@ -5673,6 +5536,11 @@ prepend-http@^1.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
 
+prettier@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
+  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
+
 pretty-error@^2.0.2:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/pretty-error/-/pretty-error-2.1.1.tgz#5f4f87c8f91e5ae3f3ba87ab4cf5e03b1a17f1a3"
@@ -5751,6 +5619,11 @@ prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
   integrity sha1-0/wRS6BplaRexok/SEzrHXj19HY=
+
+pseudomap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+  integrity sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==
 
 psl@^1.1.28:
   version "1.8.0"
@@ -5841,11 +5714,6 @@ querystringify@^2.1.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
   integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
-
-quick-lru@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
-  integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
 
 raf@^3.4.0:
   version "3.4.1"
@@ -5955,6 +5823,14 @@ read-chunk@^1.0.1:
   resolved "https://registry.yarnpkg.com/read-chunk/-/read-chunk-1.0.1.tgz#5f68cab307e663f19993527d9b589cace4661194"
   integrity sha1-X2jKswfmY/GZk1J9m1icrORmEZQ=
 
+read-pkg-up@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"
+  integrity sha512-WD9MTlNtI55IwYUS27iHh9tK3YoIVhxis8yKhLpTqWtml739uXc9NWTpxoHkfZf3+DkCCsXox94/VWZniuZm6A==
+  dependencies:
+    find-up "^1.0.0"
+    read-pkg "^1.0.0"
+
 read-pkg-up@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-2.0.0.tgz#6b72a8048984e0c41e79510fd5e9fa99b3b549be"
@@ -5963,14 +5839,14 @@ read-pkg-up@^2.0.0:
     find-up "^2.0.0"
     read-pkg "^2.0.0"
 
-read-pkg-up@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-7.0.1.tgz#f3a6135758459733ae2b95638056e1854e7ef507"
-  integrity sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==
+read-pkg@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28"
+  integrity sha512-7BGwRHqt4s/uVbuyoeejRn4YmFnYZiFl4AuaeXHlgZf3sONF0SOGlxs2Pw8g6hCKupo08RafIO5YXFNOKTfwsQ==
   dependencies:
-    find-up "^4.1.0"
-    read-pkg "^5.2.0"
-    type-fest "^0.8.1"
+    load-json-file "^1.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^1.0.0"
 
 read-pkg@^2.0.0:
   version "2.0.0"
@@ -5980,16 +5856,6 @@ read-pkg@^2.0.0:
     load-json-file "^2.0.0"
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
-
-read-pkg@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-5.2.0.tgz#7bf295438ca5a33e56cd30e053b34ee7250c93cc"
-  integrity sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==
-  dependencies:
-    "@types/normalize-package-data" "^2.4.0"
-    normalize-package-data "^2.5.0"
-    parse-json "^5.0.0"
-    type-fest "^0.6.0"
 
 "readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.6"
@@ -6023,15 +5889,6 @@ readable-stream@^3.0.6, readable-stream@^3.1.1:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
-readable-stream@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
-  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
-  dependencies:
-    inherits "^2.0.3"
-    string_decoder "^1.1.1"
-    util-deprecate "^1.0.1"
-
 readdirp@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.2.1.tgz#0e87622a3325aa33e892285caf8b4e846529a525"
@@ -6041,13 +5898,13 @@ readdirp@^2.2.1:
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
 
-redent@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/redent/-/redent-3.0.0.tgz#e557b7998316bb53c9f1f56fa626352c6963059f"
-  integrity sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==
+redent@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-1.0.0.tgz#cf916ab1fd5f1f16dfb20822dd6ec7f730c2afde"
+  integrity sha512-qtW5hKzGQZqKoh6JNSD+4lfitfPKGz42e6QwiRmPM5mmKtR0N41AbJRYu0xJi7nhOJ4WDgRkKvAk6tw4WIwR4g==
   dependencies:
-    indent-string "^4.0.0"
-    strip-indent "^3.0.0"
+    indent-string "^2.1.0"
+    strip-indent "^1.0.1"
 
 reflect.ownkeys@^0.2.0:
   version "0.2.0"
@@ -6103,6 +5960,13 @@ repeat-string@^1.6.1:
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
 
+repeating@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
+  integrity sha512-ZqtSMuVybkISo2OWvqvm7iHSWngvdaW3IpsT9/uP8v4gMi591LY6h35wdOfvQdWCKFWZWm2Y1Opp4kV7vQKT6A==
+  dependencies:
+    is-finite "^1.0.0"
+
 replace-ext@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-0.0.1.tgz#29bbd92078a739f0bcce2b4ee41e837953522924"
@@ -6115,7 +5979,7 @@ request-progress@^2.0.1:
   dependencies:
     throttleit "^1.0.0"
 
-request@^2.65.0, request@^2.81.0, request@^2.88.0, request@^2.88.2:
+request@^2.65.0, request@^2.81.0, request@^2.87.0, request@^2.88.0:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
@@ -6228,17 +6092,17 @@ retry@^0.12.0:
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
   integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
 
+rimraf@2:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
+  integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
+  dependencies:
+    glob "^7.1.3"
+
 rimraf@2.6.3, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
-  dependencies:
-    glob "^7.1.3"
-
-rimraf@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
-  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 
@@ -6380,12 +6244,10 @@ semver@^6.0.0, semver@^6.1.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.2.0.tgz#4d813d9590aaf8a9192693d6c85b9344de5901db"
   integrity sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A==
 
-semver@^7.3.2, semver@^7.3.4:
-  version "7.3.7"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
-  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
-  dependencies:
-    lru-cache "^6.0.0"
+semver@~5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
+  integrity sha512-mfmm3/H9+67MCVix1h+IXTpDwL6710LyHuk7+cWC9T1mE0qz4iHhh6r4hU2wrIT9iTsAAC2XQRvfblL028cpLw==
 
 send@0.17.1:
   version "0.17.1"
@@ -6488,22 +6350,10 @@ shebang-command@^1.2.0:
   dependencies:
     shebang-regex "^1.0.0"
 
-shebang-command@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
-  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
-  dependencies:
-    shebang-regex "^3.0.0"
-
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
-
-shebang-regex@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
-  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
@@ -6806,15 +6656,6 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
 string-width@^3.0.0, string-width@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
@@ -6873,12 +6714,12 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   dependencies:
     ansi-regex "^4.1.0"
 
-strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+strip-bom@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
+  integrity sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g==
   dependencies:
-    ansi-regex "^5.0.1"
+    is-utf8 "^0.2.0"
 
 strip-bom@^3.0.0:
   version "3.0.0"
@@ -6890,12 +6731,12 @@ strip-eof@^1.0.0:
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
   integrity sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=
 
-strip-indent@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-3.0.0.tgz#c32e1cee940b6b3432c771bc2c54bcce73cd3001"
-  integrity sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==
+strip-indent@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-1.0.1.tgz#0c7962a6adefa7bbd4ac366460a638552ae1a0a2"
+  integrity sha512-I5iQq6aFMM62fBEAIB/hXzwJD6EEZ0xEGCX2t7oXqaKPIRgt4WruAQ285BISgdkP+HLGWyeGmNJcpIwFeRYRUA==
   dependencies:
-    min-indent "^1.0.0"
+    get-stdin "^4.0.1"
 
 strip-json-comments@2.0.1, strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"
@@ -6928,19 +6769,17 @@ supports-color@6.1.0, supports-color@^6.1.0:
   dependencies:
     has-flag "^3.0.0"
 
+supports-color@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
+  integrity sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==
+
 supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
   dependencies:
     has-flag "^3.0.0"
-
-supports-color@^7.1.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
-  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
-  dependencies:
-    has-flag "^4.0.0"
 
 svg2png@~3.0.1:
   version "3.0.1"
@@ -6966,6 +6805,15 @@ tapable@^1.0.0, tapable@^1.1.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
+tar@^2.0.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.2.tgz#0ca8848562c7299b8b446ff6a4d60cdbb23edc40"
+  integrity sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==
+  dependencies:
+    block-stream "*"
+    fstream "^1.0.12"
+    inherits "2"
+
 tar@^4:
   version "4.4.10"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.10.tgz#946b2810b9a5e0b26140cf78bea6b0b0d689eba1"
@@ -6978,18 +6826,6 @@ tar@^4:
     mkdirp "^0.5.0"
     safe-buffer "^5.1.2"
     yallist "^3.0.3"
-
-tar@^6.0.2:
-  version "6.1.11"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.11.tgz#6760a38f003afa1b2ffd0ffe9e9abbd0eab3d621"
-  integrity sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==
-  dependencies:
-    chownr "^2.0.0"
-    fs-minipass "^2.0.0"
-    minipass "^3.0.0"
-    minizlib "^2.1.1"
-    mkdirp "^1.0.3"
-    yallist "^4.0.0"
 
 terser-webpack-plugin@^1.1.0:
   version "1.3.0"
@@ -7134,10 +6970,10 @@ tough-cookie@~2.5.0:
     psl "^1.1.28"
     punycode "^2.1.1"
 
-trim-newlines@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
-  integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
+trim-newlines@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
+  integrity sha512-Nm4cF79FhSTzrLKGDMi3I4utBtFv8qKy4sq1enftf2gMdpqI8oVQTAfySkTz5r49giVzDj88SVZXP4CeYQwjaw==
 
 trim-repeated@^1.0.0:
   version "1.0.0"
@@ -7210,21 +7046,6 @@ type-check@~0.3.2:
   integrity sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
   dependencies:
     prelude-ls "~1.1.2"
-
-type-fest@^0.18.0:
-  version "0.18.1"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.18.1.tgz#db4bc151a4a2cf4eebf9add5db75508db6cc841f"
-  integrity sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==
-
-type-fest@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
-  integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
-
-type-fest@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
-  integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
 type-is@~1.6.17, type-is@~1.6.18:
   version "1.6.18"
@@ -7582,17 +7403,10 @@ which-module@^2.0.0:
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
-which@1.3.1, which@^1.2.10, which@^1.2.14, which@^1.2.9, which@^1.3.1:
+which@1, which@1.3.1, which@^1.2.10, which@^1.2.14, which@^1.2.9, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
-  dependencies:
-    isexe "^2.0.0"
-
-which@^2.0.1, which@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
-  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
 
@@ -7602,13 +7416,6 @@ wide-align@1.1.3, wide-align@^1.1.0:
   integrity sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==
   dependencies:
     string-width "^1.0.2 || 2"
-
-wide-align@^1.1.2:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.5.tgz#df1d4c206854369ecf3c9a4898f1b23fbd9d15d3"
-  integrity sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==
-  dependencies:
-    string-width "^1.0.2 || 2 || 3 || 4"
 
 window-size@^0.1.4:
   version "0.1.4"
@@ -7699,15 +7506,15 @@ y18n@^3.2.0:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
 
+yallist@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+  integrity sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==
+
 yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
   integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
-
-yallist@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
-  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yargs-parser@13.0.0:
   version "13.0.0"
@@ -7740,11 +7547,6 @@ yargs-parser@^13.1.2:
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
-
-yargs-parser@^20.2.3:
-  version "20.2.9"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
-  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
 yargs-unparser@1.5.0:
   version "1.5.0"


### PR DESCRIPTION
* adds a new optional parameter `renderContext` to `renderContent`, which enables custom conditional rendering such as comments or code annotations 
* adds Prettier, synced with ESLint/TypeScript, switches to strings, size 4
* updates README with a hint on how to build the examples using certain `node` and `node-sass` versions