### PR TITLE
feat: add missing codeFold to ReactDiffViewerStylesOverride

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -72,6 +72,7 @@ export interface ReactDiffViewerStylesOverride {
 	wordAdded?: Interpolation;
 	wordRemoved?: Interpolation;
 	codeFoldGutter?: Interpolation;
+	codeFold?: Interpolation;
 	emptyLine?: Interpolation;
 	content?: Interpolation;
 	titleBlock?: Interpolation;


### PR DESCRIPTION
Apparently, `codeFold` is missing in `ReactDiffViewerStylesOverride` interface, though it's marked as an option to configure in `README.md`. I'm adding it in this PR.